### PR TITLE
Calculation of the total photon number distribution of a given pure state

### DIFF
--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -35,6 +35,8 @@ from thewalrus.quantum import (
     pure_state_amplitude,
     state_vector,
     is_classical_cov,
+    total_photon_num_dist_pure_state,
+    gen_single_mode_dist,
 )
 
 
@@ -674,3 +676,16 @@ def test_is_classical_cov_thermal(nbar):
     """ Tests that a thermal state is classical"""
     cov = (2 * nbar + 1) * np.identity(2)
     assert is_classical_cov(cov)
+
+
+def test_total_photon_num_dist_pure_state():
+    """ Test the correct photon number distribution is obtained for n modes
+    with nmean number of photons up to Fock cutoff nmax"""
+    n = 3
+    nmean = 1.0
+    nmax = 50
+    rs = np.arcsinh(np.sqrt(nmean)) * np.ones([n])
+    cov = np.diag(np.concatenate([np.exp(2 * rs), np.exp(-2 * rs)]))
+    p1 = total_photon_num_dist_pure_state(cov, nmax=nmax)
+    p2 = gen_single_mode_dist(np.arcsinh(np.sqrt(nmean)), N=n, nmax=nmax)
+    assert np.allclose(p1, p2)


### PR DESCRIPTION
**Context:**
For certain properties of GBS it is useful to know in advance what is the probability that a total of N photons are counted in all of the modes. This probability distribution can be calculated efficiently for pure states and this PR provides functions for doing so.
**Description of the Change:**
Adds ```gen_multi_mode_dist```, ```total_photon_num_dist_pure_state``` and ```gen_single_mode_dist``` into `quantum.py`
**Benefits:**
Can calculate the total photon number distribution.

