### PR TITLE
Integration tests

### DIFF
--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 """Tests for The Walrus quantum functions"""
 # pylint: disable=no-self-use,redefined-outer-name
-import pytest
 
 import numpy as np
 from thewalrus.quantum import (
-    density_matrix_element,
     density_matrix,
-    pure_state_amplitude,
     state_vector,
 )
 

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -16,40 +16,39 @@
 import pytest
 
 import numpy as np
-from thewalrus.quantum import density_matrix_element, density_matrix, pure_state_amplitude, state_vector
-
-mu = np.array([-0.50047867,  0.37373598,  0.01421683,  0.26999427,  0.04450994,  0.01903583])
-
-cov = np.array([[ 1.57884241,  0.81035494,  1.03468307,  1.14908791,  0.09179507, -0.11893174],
-       [ 0.81035494,  1.06942863,  0.89359234,  0.20145142,  0.16202296,  0.4578259 ],
-       [ 1.03468307,  0.89359234,  1.87560498,  0.16915661,  1.0836528 , -0.09405278],
-       [ 1.14908791,  0.20145142,  0.16915661,  2.37765137, -0.93543385, -0.6544286 ],
-       [ 0.09179507,  0.16202296,  1.0836528 , -0.93543385,  2.78903152, -0.76519088],
-       [-0.11893174,  0.4578259 , -0.09405278, -0.6544286 , -0.76519088,  1.51724222]])
-
-cutoff=15
-# the Fock state measurement of mode 0 to be post-selected
-m1 = 1
-# the Fock state measurement of mode 1 to be post-selected
-m2 = 2
+from thewalrus.quantum import (
+    density_matrix_element,
+    density_matrix,
+    pure_state_amplitude,
+    state_vector,
+)
 
 
-@pytest.mark.parametrize("mu", [mu, np.zeros_like(mu)])
-def test_preparation_without_displacement(mu):
-	psi = state_vector(0*mu, cov, post_select={0: m1, 1: m2}, cutoff=cutoff, hbar=2)
-	psi_c = state_vector(0*mu, cov, cutoff=cutoff, hbar=2)
-	rho = density_matrix(0*mu, cov, post_select={0: m1, 1: m2}, cutoff=cutoff, hbar=2)
-	rho_c = density_matrix(0*mu, cov, cutoff=cutoff, hbar=2)
-	ps_psi = np.abs(psi)**2
-	ps_psi_c = np.abs(psi_c[m1,m2])**2
-	ps_rho = np.diag(rho)
-	ps_rho_c = np.diag(rho_c[m1,m1,m2,m2,:,:])
-	# Test the probabilities from density matrices are real
-	assert np.allclose(ps_rho.imag, np.zeros_like(ps_rho), rtol=0)
-	assert np.allclose(ps_rho_c.imag, np.zeros_like(ps_rho_c), rtol=0)
-	ps_rho = ps_rho.real
-	ps_rho_c = ps_rho_c.real
-	# Verify that all the probabilities are equal
-	assert np.allclose(ps_rho, ps_rho_c)
-	assert np.allclose(ps_rho, ps_psi)
-	assert np.allclose(ps_rho, ps_psi_c)
+def test_cubic_phase():
+    """Test that all the possible ways of obtaining a cubic phase state using the different methods agree"""
+    mu = np.array([-0.50047867, 0.37373598, 0.01421683, 0.26999427, 0.04450994, 0.01903583])
+
+    cov = np.array(
+        [
+            [1.57884241, 0.81035494, 1.03468307, 1.14908791, 0.09179507, -0.11893174],
+            [0.81035494, 1.06942863, 0.89359234, 0.20145142, 0.16202296, 0.4578259],
+            [1.03468307, 0.89359234, 1.87560498, 0.16915661, 1.0836528, -0.09405278],
+            [1.14908791, 0.20145142, 0.16915661, 2.37765137, -0.93543385, -0.6544286],
+            [0.09179507, 0.16202296, 1.0836528, -0.93543385, 2.78903152, -0.76519088],
+            [-0.11893174, 0.4578259, -0.09405278, -0.6544286, -0.76519088, 1.51724222],
+        ]
+    )
+
+    cutoff = 7
+    # the Fock state measurement of mode 0 to be post-selected
+    m1 = 1
+    # the Fock state measurement of mode 1 to be post-selected
+    m2 = 2
+
+    psi = state_vector(mu, cov, post_select={0: m1, 1: m2}, cutoff=cutoff, hbar=2)
+    psi_c = state_vector(mu, cov, cutoff=cutoff, hbar=2)[m1, m2, :]
+    rho = density_matrix(mu, cov, post_select={0: m1, 1: m2}, cutoff=cutoff, hbar=2)
+    rho_c = density_matrix(mu, cov, cutoff=cutoff, hbar=2)[m1, m2, :, m1, m2, :]
+    assert np.allclose(np.outer(psi, psi.conj()), rho)
+    assert np.allclose(np.outer(psi_c, psi_c.conj()), rho)
+    assert np.allclose(rho_c, rho)

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -1,0 +1,55 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for The Walrus quantum functions"""
+# pylint: disable=no-self-use,redefined-outer-name
+import pytest
+
+import numpy as np
+from thewalrus.quantum import density_matrix_element, density_matrix, pure_state_amplitude, state_vector
+
+mu = np.array([-0.50047867,  0.37373598,  0.01421683,  0.26999427,  0.04450994,  0.01903583])
+
+cov = np.array([[ 1.57884241,  0.81035494,  1.03468307,  1.14908791,  0.09179507, -0.11893174],
+       [ 0.81035494,  1.06942863,  0.89359234,  0.20145142,  0.16202296,  0.4578259 ],
+       [ 1.03468307,  0.89359234,  1.87560498,  0.16915661,  1.0836528 , -0.09405278],
+       [ 1.14908791,  0.20145142,  0.16915661,  2.37765137, -0.93543385, -0.6544286 ],
+       [ 0.09179507,  0.16202296,  1.0836528 , -0.93543385,  2.78903152, -0.76519088],
+       [-0.11893174,  0.4578259 , -0.09405278, -0.6544286 , -0.76519088,  1.51724222]])
+
+cutoff=15
+# the Fock state measurement of mode 0 to be post-selected
+m1 = 1
+# the Fock state measurement of mode 1 to be post-selected
+m2 = 2
+
+
+@pytest.mark.parametrize("mu", [mu, np.zeros_like(mu)])
+def test_preparation_without_displacement(mu):
+	psi = state_vector(0*mu, cov, post_select={0: m1, 1: m2}, cutoff=cutoff, hbar=2)
+	psi_c = state_vector(0*mu, cov, cutoff=cutoff, hbar=2)
+	rho = density_matrix(0*mu, cov, post_select={0: m1, 1: m2}, cutoff=cutoff, hbar=2)
+	rho_c = density_matrix(0*mu, cov, cutoff=cutoff, hbar=2)
+	ps_psi = np.abs(psi)**2
+	ps_psi_c = np.abs(psi_c[m1,m2])**2
+	ps_rho = np.diag(rho)
+	ps_rho_c = np.diag(rho_c[m1,m1,m2,m2,:,:])
+	# Test the probabilities from density matrices are real
+	assert np.allclose(ps_rho.imag, np.zeros_like(ps_rho), rtol=0)
+	assert np.allclose(ps_rho_c.imag, np.zeros_like(ps_rho_c), rtol=0)
+	ps_rho = ps_rho.real
+	ps_rho_c = ps_rho_c.real
+	# Verify that all the probabilities are equal
+	assert np.allclose(ps_rho, ps_rho_c)
+	assert np.allclose(ps_rho, ps_psi)
+	assert np.allclose(ps_rho, ps_psi_c)

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -372,7 +372,11 @@ def test_coherent_squeezed():
          [0.07862323 + 0.00868528j, 0.01274241 + 0.00614023j, -0.02127257 - 0.00122123j, -0.00624626 - 0.00288134j, 0.00702606]]
     )
     # fmt:on
+    np.set_printoptions(linewidth=200)
 
+    print("\n")
+    print(np.round(res,4))
+    print(np.round(expected,4))
     assert np.allclose(res, expected)
 
 
@@ -529,7 +533,7 @@ def test_is_pure_cov_thermal(nbar):
 
 @pytest.mark.parametrize("i", [0, 1, 2, 3, 4])
 @pytest.mark.parametrize("j", [0, 1, 2, 3, 4])
-def test_pure_state_amplitude_two_mode_squezed(i, j):
+def test_pure_state_amplitude_two_mode_squeezed(i, j):
     """ Tests pure state amplitude for a two mode squeezed vacuum state """
     nbar = 1.0
     phase = np.pi / 8
@@ -539,8 +543,9 @@ def test_pure_state_amplitude_two_mode_squezed(i, j):
     if i != j:
         exact = 0.0
     else:
-        exact = np.exp(-1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar)
+        exact = np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar)
     num = pure_state_amplitude(mu, cov, [i, j])
+
     assert np.allclose(exact, num)
 
 
@@ -587,7 +592,7 @@ def test_state_vector_two_mode_squeezed():
     mu = np.zeros([4], dtype=np.complex)
     exact = np.array(
         [
-            (np.exp(-1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
+            (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
             for i in range(cutoff)
         ]
     )
@@ -607,7 +612,7 @@ def test_state_vector_two_mode_squeezed_post():
     exact = np.diag(
         np.array(
             [
-                (np.exp(-1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
+                (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
                 for i in range(cutoff)
             ]
         )
@@ -647,7 +652,7 @@ def test_state_vector_two_mode_squeezed_post_normalize():
     exact = np.diag(
         np.array(
             [
-                (np.exp(-1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
+                (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
                 for i in range(cutoff)
             ]
         )

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -372,11 +372,6 @@ def test_coherent_squeezed():
          [0.07862323 + 0.00868528j, 0.01274241 + 0.00614023j, -0.02127257 - 0.00122123j, -0.00624626 - 0.00288134j, 0.00702606]]
     )
     # fmt:on
-    np.set_printoptions(linewidth=200)
-
-    print("\n")
-    print(np.round(res,4))
-    print(np.round(expected,4))
     assert np.allclose(res, expected)
 
 


### PR DESCRIPTION
Adds an integration test to check for the different ways in which one can calculate density matrices using the functions in quantum.
It also fixes a number of issues in quantum and test_quantum related to displacements.