### PR TITLE
fixes #57 and #56

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-EIGEN_INCLUDE_DIR=/usr/include/eigen3
+EIGEN_INCLUDE_DIR?=/usr/include/eigen3
 
 CC=g++
 CFLAGS=-std=c++11 -O3 -Wall -I/usr/include -I../include -I$(EIGEN_INCLUDE_DIR) -fopenmp -march=native
 LFLAGS=-L/usr/lib -lm -fopenmp
 
-all: example-f90 example-cpp
+all: example-cpp
 
-example.o: example.cpp libwalrus.hpp
+example.o: example.cpp
 	$(CC) $^ $(CFLAGS) -c
 
 example-cpp: example.o

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,16 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-EIGEN_INCLUDE_DIR=/usr/include/eigen3
-#C_INCLUDE_PATH = /opt/local/include/libomp/
-#C_LIBRARY_PATH = /opt/local/lib/libomp/
-#LD_LIBRARY_PATH = /opt/local/lib/libomp/
-CC=g++
-CFLAGS=-std=c++11 -O3 -g -Wall -fopenmp -fPIC -I/usr/include \
+EIGEN_INCLUDE_DIR ?= /usr/include/eigen3
+CC = g++
+CFLAGS = -std=c++11 -O3 -g -Wall -fopenmp -fPIC -I/usr/include \
 	-I../include -I$(EIGEN_INCLUDE_DIR) -I$(GOOGLETEST_DIR)/include \
 	-march=native
 
-LFLAGS=-fopenmp -L$(GOOGLETEST_DIR)/lib -lgtest
+LFLAGS = -fopenmp -L$(GOOGLETEST_DIR)/lib -lgtest
 
 all: test
 


### PR DESCRIPTION
**Description of the Change:** Updates the makefile to by default use a defined environment variable `EIGEN_INCLUDE_DIR` for the location of the eigen3 include directory. If not defined, it falls back to `/usr/include/eigen3`. Also removes `example-f90` target from the examples makefile.

**Benefits:** More easily installable

**Possible Drawbacks:** n/a

**Related GitHub Issues:** Fixes #56 and #57
