### PR TITLE
Minor tweaks

### DIFF
--- a/docs/gbs.rst
+++ b/docs/gbs.rst
@@ -82,14 +82,14 @@ Similarly the complex normal covariance matrix :math:`\sigma` of the variables :
 
 .. tip::
 
-   * To inter convert between the complex covariance matrix :math:`\sigma` and the quadrature covariance matrix :math:`\mathbf{V}` use the functions :func:`thewalrus.quantum.Qmat` and :func:`thewalrus.quantum.Covmat`
+   To convert between the complex covariance matrix :math:`\sigma` and the quadrature covariance matrix :math:`\mathbf{V}` use the functions :func:`thewalrus.quantum.Qmat` and :func:`thewalrus.quantum.Covmat`
 
 
 An important property of Gaussian states is that reduced (or marginal) states of a global Gaussian state are also Gaussian. This implies that the reduced covariance matrix of a subsystem of a Gaussian state together with a reduced vector of means fully characterize a reduced Gaussian state. The reduced covariance matrix for modes :math:`S = i_1,\ldots,i_n` is obtained from the covariance matrix of the global state :math:`sigma` or :math:`\mathbf{V}` by keeping the columns and rows  :math:`i_1,\ldots,i_n` and :math:`i_1+\ell,\ldots,i_n+\ell` of the original covariance matrix :math:`\sigma`. Similarly one obtains the vector of means by keeping only entries :math:`i_1,\ldots,i_n` and :math:`i_1+\ell,\ldots,i_n+\ell` of the original vector of means :math:`\vec \beta` or :math:`\mathbf{\bar{r}}`. Using the :ref:`notation <notation>` previously introduced, one can succinctly write the covariance matrix of modes :math:`S=i_1,\ldots,i_m` as :math:`\sigma_{(S)}` or :math:`\mathbf{V}_{(S)}` , and similarly the vector of means as :math:`\vec{\beta}_{(S)}` or :math:`\mathbf{\bar{r}}_{(S)}`.
 
 .. tip::
 
-   * To obtain the reduced covariance matrix and vector of means for a certain subset of the modes use :func:`thewalrus.quantum.reduced_gaussian`.
+   To obtain the reduced covariance matrix and vector of means for a certain subset of the modes use :func:`thewalrus.quantum.reduced_gaussian`.
 
 
 Note that for :math:`\mathbf{V}` to be a valid **quantum** covariance matrix it needs to be symmetric and satisfy the uncertainty relation
@@ -100,13 +100,13 @@ Note that for :math:`\mathbf{V}` to be a valid **quantum** covariance matrix it 
 
 .. tip::
 
-   * To verify if a given quadrature covariance matrix is a valid quantum covariance matrix use the function :func:`thewalrus.quantum.is_valid_cov`
+   To verify if a given quadrature covariance matrix is a valid quantum covariance matrix use the function :func:`thewalrus.quantum.is_valid_cov`
 
-A Gaussian state is pure :math:`\varrho = \ket{\psi} \bra{\psi}` if and only if :math:`\text{det}(\mathbf{V}/\tfrac{\hbar}{2}) = 1`.
+A Gaussian state is pure :math:`\varrho = \ket{\psi} \bra{\psi}` if and only if :math:`\text{det}\left( \tfrac{2}{\hbar} \mathbf{V} \right) = 1`.
 
 .. tip::
 
-   * To verify if a given quadrature covariance matrix is a valid quantum covariance matrix and corresponds to a pure state use the function :func:`thewalrus.quantum.is_pure_cov`
+   To verify if a given quadrature covariance matrix is a valid quantum covariance matrix and corresponds to a pure state use the function :func:`thewalrus.quantum.is_pure_cov`
 
 Finally, there is a special subset of Gaussian states called **classical** whose covariance matrix satisfies
 
@@ -117,7 +117,7 @@ This terminology is explained in the next section when sampling is discussed.
 
 .. tip::
 
-   * To verify if a given quadrature covariance matrix is a valid quantum covariance matrix and corresponds to a classical state use the function :func:`thewalrus.quantum.is_classical_cov`
+   To verify if a given quadrature covariance matrix is a valid quantum covariance matrix and corresponds to a classical state use the function :func:`thewalrus.quantum.is_classical_cov`
 
 
 
@@ -154,11 +154,11 @@ Note that one can also obtain the probability of detecting a certain photon numb
 
 .. tip::
 
-   * To obtain the matrix element of gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` use the function :func:`thewalrus.quantum.density_matrix_element`.
+   To obtain the matrix element of gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` use the function :func:`thewalrus.quantum.density_matrix_element`.
 
 .. tip::
 
-   * To obtain the Fock space density matrix of gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` use the function :func:`thewalrus.quantum.density_matrix`.
+   To obtain the Fock space density matrix of gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` use the function :func:`thewalrus.quantum.density_matrix`.
 
 
 In the case where the Gaussian state :math:`\varrho = |\psi \rangle \langle \psi|` is pure then the matrix element
@@ -171,11 +171,11 @@ factorizes into a product of two amplitudes. In Ref. :cite:`quesada2019franck` i
 
 .. tip::
 
-   * To obtain the overlap of a *pure* gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` and a given Fock state :math:`\langle \mathbf{n}|` use the function :func:`thewalrus.quantum.pure_state_amplitude`.
+   To obtain the overlap of a *pure* gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` and a given Fock state :math:`\langle \mathbf{n}|` use the function :func:`thewalrus.quantum.pure_state_amplitude`.
 
 .. tip::
 
-   * To obtain the Fock space state vector (ket) of a pure gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` use the function :func:`thewalrus.quantum.state_vector`.
+   To obtain the Fock space state vector (ket) of a pure gaussian state with quadrature covariance matrix :math:`\mathbf{V}` and vector of means :math:`\mathbf{r}` use the function :func:`thewalrus.quantum.state_vector`.
 
 
 
@@ -204,7 +204,7 @@ The torontonian can be thought of as a generating function for hafnians (cf. the
 
 .. tip::
 
-   * The torontonian is implemented as :func:`thewalrus.tor`.
+   The torontonian is implemented as :func:`thewalrus.tor`.
 
 
 

--- a/docs/gbs_sampling.rst
+++ b/docs/gbs_sampling.rst
@@ -57,7 +57,7 @@ where :math:`p(N_{k-1}=n_{k-1},\ldots,N_0=n_0)` has already been calculated from
 
 .. tip::
 
-   * To generate samples from a gaussian state specified by a quadrature covariance matrix use :func:`thewalrus.samples.generate_hafnian_sample`.
+   To generate samples from a gaussian state specified by a quadrature covariance matrix use :func:`thewalrus.samples.generate_hafnian_sample`.
 
       Note that the above algorithm can also be generalized to states with finite means for which one only needs to provide the mean with the optional argument ``mean``.
 
@@ -68,15 +68,15 @@ Note the arguments presented in the previous section can also be generalized to 
 
 .. tip::
 
-   * To generate threshold samples from a gaussian state specified by a quadrature covariance matrix use :func:`thewalrus.samples.generate_torontonian_sample`.
+   To generate threshold samples from a gaussian state specified by a quadrature covariance matrix use :func:`thewalrus.samples.generate_torontonian_sample`.
 
 
 Sampling of classical states
 ****************************
 
-In the previous section it was mentioned that states whose covariance matrix satisfies :math:`\mathbf{V} \geq \mathbb{I}` are termed classical. These designation is due to the fact that for these states it is possible to obtain a polynomial (cubic) time algorithm to generate photon number or threshold samples :cite:`rahimi2015can`.
+In the previous section it was mentioned that states whose covariance matrix satisfies :math:`\mathbf{V} \geq \frac{\hbar}{2}\mathbb{I}` are termed classical. These designation is due to the fact that for these states it is possible to obtain a polynomial (cubic) time algorithm to generate photon number or threshold samples :cite:`rahimi2015can`.
 
 .. tip::
 
-   * To generate photon number or threshold samples from a classical gaussian state specified by a quadrature covariance matrix use :func:`thewalrus.samples.hafnian_sample_classical_state` or :func:`thewalrus.samples.torontonian_sample_classical_state`.
+   To generate photon number or threshold samples from a classical gaussian state specified by a quadrature covariance matrix use :func:`thewalrus.samples.hafnian_sample_classical_state` or :func:`thewalrus.samples.torontonian_sample_classical_state`.
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -264,8 +264,7 @@
   issue = {3},
   pages = {032326},
   numpages = {15},
-  year = {2019},
-  doi = {10.1103/PhysRevA.100.032326}
+  year = {2019}
 }
 
 @article{2016arXiv160107518B,
@@ -354,9 +353,7 @@
   volume="68",
   number="1",
   pages="39--47",
-  issn="1573-7586",
-  doi="10.1007/s10623-012-9618-1",
-  url="https://doi.org/10.1007/s10623-012-9618-1"
+  issn="1573-7586"
 }
 
 @article{BaxFranklin,
@@ -493,8 +490,7 @@
   issue = {2},
   pages = {022341},
   numpages = {10},
-  year = {2019},
-  doi = {10.1103/PhysRevA.100.022341}
+  year = {2019}
 }
 
 @article{mizrahi1975generalized,

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -83,7 +83,7 @@ def hermite_multidimensional(R, cutoff, y=None, renorm=False, make_tensor=True):
         cutoff (int): maximum size of the subindices in the Hermite polynomial
         y (array): vector argument of the Hermite polynomial
         renorm (bool): If ``True``, normalizes the returned multidimensional Hermite
-            polynomials such that :math:`H_k^{(R)}(y)/\prod(\prod_i k_i!)`
+            polynomials such that :math:`H_k^{(R)}(y)/\prod_i k_i!`
         make_tensor: If ``False``, returns a flattened one dimensional array
             containing the values of the polynomial
 

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -24,19 +24,20 @@ For more details on how the hafnian relates to various properties of Gaussian qu
 states, see:
 
 * Kruse, R., Hamilton, C. S., Sansoni, L., Barkhofen, S., Silberhorn, C., & Jex, I.
-  "A detailed study of Gaussian Boson Sampling." `arXiv:1801.07488. (2018).
-  <https://arxiv.org/abs/1801.07488>`_
+  "Detailed study of Gaussian boson sampling." `Physical Review A 100, 032326 (2019)
+  <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.100.032326>`_
 
 * Hamilton, C. S., Kruse, R., Sansoni, L., Barkhofen, S., Silberhorn, C., & Jex, I.
-  "Gaussian boson sampling." `Physical review letters, 119(17), 170501. (2017).
+  "Gaussian boson sampling." `Physical Review Letters, 119(17), 170501 (2017)
   <https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.119.170501>`_
 
 * Quesada, N.
   "Franck-Condon factors by counting perfect matchings of graphs with loops."
-  `Journal of Chemical Physics 150, 164113 (2019). <https://aip.scitation.org/doi/10.1063/1.5086387>`_
+  `Journal of Chemical Physics 150, 164113 (2019) <https://aip.scitation.org/doi/10.1063/1.5086387>`_
 
 * Quesada, N., Helt, L. G., Izaac, J., Arrazola, J. M., Shahrokhshahi, R., Myers, C. R., & Sabapathy, K. K.
-  "Simulating realistic non-Gaussian state preparation." `arXiv:1905.07011. (2019). <https://arxiv.org/abs/1905.07011>`_
+  "Simulating realistic non-Gaussian state preparation." `Phys. Rev. A 100, 022341 (2019)
+ <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.100.022341>`_
 
 
 Fock states

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -36,8 +36,8 @@ states, see:
   `Journal of Chemical Physics 150, 164113 (2019) <https://aip.scitation.org/doi/10.1063/1.5086387>`_
 
 * Quesada, N., Helt, L. G., Izaac, J., Arrazola, J. M., Shahrokhshahi, R., Myers, C. R., & Sabapathy, K. K.
-  "Simulating realistic non-Gaussian state preparation." `Phys. Rev. A 100, 022341 (2019)
- <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.100.022341>`_
+  "Simulating realistic non-Gaussian state preparation." `Physical Review A 100, 022341 (2019)
+  <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.100.022341>`_
 
 
 Fock states
@@ -704,7 +704,7 @@ def is_classical_cov(cov, hbar=2, atol=1e-08):
         hbar (float): value of hbar in the uncertainty relation
 
     Returns:
-        (bool): whether the given covariance matrix corresponds to a pure state
+        (bool): whether the given covariance matrix corresponds to a classical state
     """
 
     if is_valid_cov(cov, hbar=hbar, atol=atol):


### PR DESCRIPTION
**Context:**
Fixes typos and updates bibliography. It also addresses https://github.com/XanaduAI/thewalrus/issues/45
**Description of the Change:**
Updates a number of incorrect expression in the docs, updates the bibliography and removes * from the tip boxes
**Benefits:**
Better docs
**Related GitHub Issues:**
https://github.com/XanaduAI/thewalrus/issues/45