### PR TITLE
add-classical-sampler

### DIFF
--- a/thewalrus/csamples.py
+++ b/thewalrus/csamples.py
@@ -1,0 +1,143 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""
+Classical Sampling Algorithms
+=============================
+
+.. currentmodule:: thewalrus.csamples
+
+This submodule provides access to classical sampling algorithms. 
+
+Summary
+-------
+.. autosummary::
+    rescale_adjacency_matrix_thermal
+    rescale_adjacency_matrix
+    generate_thermal_samples
+    
+Code details
+------------
+"""
+
+import numpy as np
+from scipy.optimize import root_scalar
+
+def rescale_adjacency_matrix_thermal(
+    A, n_mean, check_positivity=True, check_symmetry=True, rtol=1e-05, atol=1e-08
+):
+    r""" Returns the scaling parameter by which the adjacency matrix A
+    should be rescaled so that the Gaussian state that encodes it has
+    a total mean photon number n_mean for thermal sampling.
+    Args:
+        A (array): Adjacency matrix, assumed to be positive semi-definite and real
+        n_mean (float): Mean photon number of the Gaussian state
+        check_positivity (bool): Checks if the matrix A is positive semidefinite
+        check_symmetry (bool): Checks if the matrix is symmetric
+        rtol: relative tolerance for the checks
+        atol: absolute tolerance for the checks
+    Returns:
+        tuple(array,array): rescaled eigenvalues and eigenvectors of the matrix A
+    """
+    return rescale_adjacency_matrix(
+        A, n_mean, 1.0, check_positivity=check_positivity, check_symmetry=check_symmetry, rtol=rtol, atol=atol
+    )
+
+def rescale_adjacency_matrix(
+    A, n_mean, scale, check_positivity=True, check_symmetry=True, rtol=1e-05, atol=1e-08
+):
+    r""" Returns the scaling parameter by which the adjacency matrix A
+    should be rescaled so that the Gaussian state that encodes it has
+    a total mean photon number n_mean.
+    Args:
+        A (array): Adjacency matrix, assumed to be positive semi-definite and real
+        n_mean (float): Mean photon number of the Gaussian state
+        scale (float): Determines whether to rescale the matrix for thermal sampling (scale = 1.0)
+            or for squashed sampling (scale = 2.0)
+        check_positivity (bool): Checks if the matrix A is positive semidefinite
+        check_symmetry (bool): Checks if the matrix is symmetric
+        rtol: relative tolerance for the checks
+        atol: absolute tolerance for the checks
+    Returns:
+        tuple(array,array): rescaled eigenvalues and eigenvectors of the matrix A
+    """
+    ls, O = np.linalg.eigh(A)
+    ls[np.abs(ls) < atol] = 0.0
+
+    if check_symmetry is True:
+        assert np.allclose(A, A.T, rtol=rtol, atol=atol)
+
+    if check_positivity is True:
+        assert np.all(ls >= 0)
+        
+
+    max_sv = ls[-1]
+    a_lim = 0.0
+    b_lim = 1 / (atol + scale * max_sv)
+    x_init = 0.5 * b_lim
+
+    def mean_photon_number(x, vals):
+        r""" Returns the mean number of photons in the Gaussian state that
+        encodes the adjacency matrix x*A where vals are the eigenvalues of positive semidefinite A
+        Args:
+            x (float): Scaling parameter
+            vals (array): Eigenvalues of the matrix A
+        Returns:
+            n_mean: Mean photon number in the Gaussian state
+        """
+
+        vals2 = scale * x * vals
+        n = np.sum(vals2 / (1.0 - vals2))
+        return n
+
+    def grad_mean_photon_number(x, vals):
+        r""" Returns the gradient of the mean number of photons in the Gaussian state that
+        encodes the adjacency matrix x*A with respect to x.
+        vals are the eigenvalues of A
+        Args:
+            x (float): Scaling parameter
+            vals (array): Eigenvalues of the matrix A
+        Returns:
+            d_n_mean: Derivative of the mean photon number in the Gaussian state
+                with respect to x
+        """
+        vals1 = scale * x * vals
+        dn = np.sum((scale * vals) / (1 - vals1) ** 2)
+        return dn
+
+    f = lambda x: mean_photon_number(x, ls) - n_mean
+    df = lambda x: grad_mean_photon_number(x, ls)
+    res = root_scalar(f, fprime=df, x0=x_init, bracket=(a_lim, b_lim))
+    assert res.converged
+    return res.root * ls, O
+
+def generate_thermal_samples(ls, O, num_samples=1):
+    r""" Generates samples of the Gaussian state in terms of the mean photon number parameter ls and the interferometer O.
+        Args:
+            ls (array): squashing parameters
+            O (array): Orthogonal matrix representing the interferometer
+            num_samples: Number of samples to generate
+        Returns:
+            list(array: samples
+    """
+    rs = 0.5 * ls / (1 - ls)
+    return [
+        np.random.poisson(
+            np.abs(
+                O @ (np.random.normal(0, np.sqrt(rs))) + 1j * np.random.normal(0, np.sqrt(rs))
+            )
+            ** 2
+        )
+        for _ in range(num_samples)
+    ]
+

--- a/thewalrus/csamples.py
+++ b/thewalrus/csamples.py
@@ -17,7 +17,7 @@ Classical Sampling Algorithms
 
 .. currentmodule:: thewalrus.csamples
 
-This submodule provides access to classical sampling algorithms. 
+This submodule provides access to classical sampling algorithms.
 
 Summary
 -------
@@ -25,10 +25,11 @@ Summary
     rescale_adjacency_matrix_thermal
     rescale_adjacency_matrix
     generate_thermal_samples
-    
+
 Code details
 ------------
 """
+# pylint: disable=too-many-arguments
 
 import numpy as np
 from scipy.optimize import root_scalar
@@ -79,7 +80,6 @@ def rescale_adjacency_matrix(
 
     if check_positivity is True:
         assert np.all(ls >= 0)
-        
 
     max_sv = ls[-1]
     a_lim = 0.0
@@ -140,4 +140,3 @@ def generate_thermal_samples(ls, O, num_samples=1):
         )
         for _ in range(num_samples)
     ]
-

--- a/thewalrus/tests/test_csamples.py
+++ b/thewalrus/tests/test_csamples.py
@@ -1,0 +1,69 @@
+# Copyright 2019 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Tests for the classical sampling functions"""
+
+import pytest
+import numpy as np
+from scipy.special import factorial2
+from csamples import (
+    rescale_adjacency_matrix_thermal,
+    generate_thermal_samples,
+)
+
+rel_tol = 10
+
+def generate_positive_definite_matrix(n):
+    r"""Generates a positive definite matrix of size n
+	Args:
+		n (int) : Size of the matrix
+	Returns:
+		array: Positive definite matrix
+	"""
+    A = np.random.rand(n, n)
+    return A.T @ A
+
+def test_rescaling_thermal():
+    r"""Test that the rescaled eigenvalues of the matrix give the correct mean photon number for thermal rescaling"""
+
+    n = 10
+    A = generate_positive_definite_matrix(n)
+    n_mean = 1.0
+    ls, O = rescale_adjacency_matrix_thermal(A, n_mean)
+    assert np.allclose(n_mean, np.sum(ls / (1 - ls)))
+
+def test_mean_thermal():
+    r"""Test that the thermal samples have the correct mean photon number"""
+    n = 10
+    n_samples = 100000
+    A = generate_positive_definite_matrix(n)
+    n_mean = 10.0
+    ls, O = rescale_adjacency_matrix_thermal(A, n_mean)
+    samples = np.array(generate_thermal_samples(ls, O, num_samples=n_samples))
+    tot_photon_sample = np.sum(samples, axis=1)
+    n_mean_calc = tot_photon_sample.mean()
+    assert np.allclose(n_mean_calc, n_mean, rtol=10 / np.sqrt(n_samples))
+
+def test_dist_thermal():
+    r"""Test that the thermal sampling for a single mode produces the correct photon number distribution"""
+    n_samples = 100000
+    n_mean = 1.0
+    A = generate_positive_definite_matrix(1)
+    ls, O = rescale_adjacency_matrix_thermal(A, n_mean)
+
+    samples = np.array(generate_thermal_samples(ls, O, num_samples=n_samples))
+    bins = np.arange(0, max(samples), 1)
+    (freq, _) = np.histogram(samples, bins=bins)
+    rel_freq = freq / n_samples
+    expected = (1 / (1 + n_mean)) * (n_mean / (1 + n_mean)) ** (np.arange(len(rel_freq)))
+    assert np.allclose(rel_freq, expected, atol=10 / np.sqrt(n_samples))

--- a/thewalrus/tests/test_csamples.py
+++ b/thewalrus/tests/test_csamples.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 r"""Tests for the classical sampling functions"""
 
-import pytest
 import numpy as np
-from scipy.special import factorial2
 from csamples import (
     rescale_adjacency_matrix_thermal,
     generate_thermal_samples,
@@ -39,7 +37,7 @@ def test_rescaling_thermal():
     n = 10
     A = generate_positive_definite_matrix(n)
     n_mean = 1.0
-    ls, O = rescale_adjacency_matrix_thermal(A, n_mean)
+    ls, _ = rescale_adjacency_matrix_thermal(A, n_mean)
     assert np.allclose(n_mean, np.sum(ls / (1 - ls)))
 
 def test_mean_thermal():

--- a/thewalrus/tests/test_csamples.py
+++ b/thewalrus/tests/test_csamples.py
@@ -14,7 +14,7 @@
 r"""Tests for the classical sampling functions"""
 
 import numpy as np
-from csamples import (
+from thewalrus.csamples import (
     rescale_adjacency_matrix_thermal,
     generate_thermal_samples,
 )


### PR DESCRIPTION
------------------------------------------------------------------------------------------------------------

**Context:**
Add classical sampler algorithms to thewalrus library. 

**Description of the Change:**
A new module csamples.py is added which contains the classical algorithm for the permanental point process.
A new module test_csamples.py is added which contains the corresponding tests.
The functions in  csamples.py and test_csamples.py have be taken from the gbs-point-process repository: https://github.com/XanaduAI/gbs-point-process

**Benefits:**
The ability to use computationally-efficient classical samplers for point processes.
 
**Possible Drawbacks:**
NA

**Related GitHub Issues:**
NA
