### PR TITLE
Quad precision 80 vs 128 bits

### DIFF
--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -21,12 +21,7 @@ typedef unsigned long long int ullint;
 typedef long long int llint;
 //typedef long double qp;
 
-#if (defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__) || defined(__INTEL_COMPILER))
-typedef __float128 qp;
-//#include <quadmath.h>
-#else
-typedef long double qp;
-#endif
+
 
 /**
  * Gray code generator.

--- a/include/recursive_hafnian.hpp
+++ b/include/recursive_hafnian.hpp
@@ -194,9 +194,9 @@ std::complex<double> hafnian_recursive_quad(std::vector<std::complex<double>> &m
  * @return the hafnian
  */
 double hafnian_recursive_quad(std::vector<double> &mat) {
-    std::vector<long double> matq(mat.begin(), mat.end());
+    std::vector<qp> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
-    long double haf;
+    qp haf;
 
     if (n == 0)
         haf = 1.0;

--- a/include/stdafx.h
+++ b/include/stdafx.h
@@ -30,6 +30,13 @@ typedef std::complex<double> double_complex;
 typedef std::vector<double_complex> vec_complex;
 typedef std::vector<double> vec_double;
 
+#if (defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__) || defined(__INTEL_COMPILER))
+typedef __float128 qp;
+//#include <quadmath.h>
+#else
+typedef long double qp;
+#endif
+
 /**
  * Convert decimal number `x` to character vector `dst` of length `len`
  * representing a binary number

--- a/thewalrus/tests/test_csamples.py
+++ b/thewalrus/tests/test_csamples.py
@@ -65,3 +65,5 @@ def test_dist_thermal():
     rel_freq = freq / n_samples
     expected = (1 / (1 + n_mean)) * (n_mean / (1 + n_mean)) ** (np.arange(len(rel_freq)))
     assert np.allclose(rel_freq, expected, atol=10 / np.sqrt(n_samples))
+
+def test_multimode_thermal()


### PR DESCRIPTION
**Context:**
When calculating (real) hafnians in 'quad' precision the C++ library was using long doubles which typically means 80 bits. With the modifications in `stdafx.h` the library will try to force the compiler to use 128 bits when called in 'quad' precision mode.
**Description of the Change:**
Changes `stdafx.h` 
**Benefits:**
Increase in precision when calculating hafnians in quad mode
