### PR TITLE
Rescale fock_tensor

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,6 +20,9 @@ This release contains contributions from (in alphabetical order):
 
 Josh Izaac, Nicolas Quesada
 
+
+---
+
 # Version 0.10.0
 
 ### New features

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,25 @@
+# Version 0.11.0-dev
+
+### New features
+
+### Improvements
+
+* Updates the reference that should be used when citing The Walrus. [#102](https://github.com/XanaduAI/thewalrus/pull/102)
+
+* Updates and improves the speed and accuracy of `thewalrus.quantum.fock_tensor`. [#107](https://github.com/XanaduAI/thewalrus/pull/107)
+
+### Bug fixes
+
+* Corrects typos in describing the repeated-moment algorithm of Kan in the documentation. [#104](https://github.com/XanaduAI/thewalrus/pull/104)
+
+* Removes paper.{md,pdf,bib} from the repository now that The Walrus paper is published in Journal of Open Source Software [#106](https://github.com/XanaduAI/thewalrus/pull/106)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+Josh Izaac, Nicolas Quesada
+
 # Version 0.10.0
 
 ### New features

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,7 +21,7 @@
 #define HAFNIAN_VERSION_MAJOR 0
 
 /// The minor version number
-#define HAFNIAN_VERSION_MINOR 9
+#define HAFNIAN_VERSION_MINOR 11
 
 /// The patch number
 #define HAFNIAN_VERSION_PATCH 0
@@ -30,4 +30,4 @@
 #define HAFNIAN_VERSION_CODE (HAFNIAN_VERSION_MAJOR * 10000 + HAFNIAN_VERSION_MINOR * 100 + HAFNIAN_VERSION_PATCH)
 
 /// Version number as string
-#define HAFNIAN_VERSION_STRING "0.10.0"
+#define HAFNIAN_VERSION_STRING "0.11.0"

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0-dev"

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -501,6 +501,9 @@ def state_vector(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2, c
             relation :math:`[\x,\p]=i\hbar`.
         check_purity (bool): if ``True``, the purity of the Gaussian state is checked
             before calculating the state vector.
+        choi_r (float or None): Value of the two-mode squeezing parameter used in Choi-Jamiolkoski
+            trick in `fock_tensor`. This variable is only used when `state_vector` is called
+            by `fock_tensor`.
 
     Returns:
         np.array[complex]: the state vector of the Gaussian state
@@ -820,11 +823,6 @@ def fock_tensor(S, alpha, cutoff, choi_r=np.arcsinh(1.0), check_symplectic=True,
 
     tensor = state_vector(mu, cov, normalize=False, cutoff=cutoff, hbar=2, check_purity=False, choi_r=choi_r)
 
-    # vals = list(range(l))
-    # vals2 = list(range(l, 2 * l))
-
-    # R = np.cosh(choi_r)**l
-    # tensor = R*tensor
     if sf_order:
         sf_indexing = tuple(chain.from_iterable([[i, i + l] for i in range(l)]))
         return tensor.transpose(sf_indexing)

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -474,7 +474,7 @@ def pure_state_amplitude(mu, cov, i, include_prefactor=True, tol=1e-10, hbar=2, 
     return haf / np.sqrt(np.prod(fac(rpt)) * np.sqrt(np.linalg.det(Q)))
 
 
-def state_vector(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2, check_purity=True):
+def state_vector(mu, cov, normalize=False, post_select=None, cutoff=5, hbar=2, check_purity=True, extra_args=None):
     r"""Returns the state vector of a (PNR post-selected) Gaussian state.
 
     The resulting density matrix will have shape
@@ -522,6 +522,11 @@ def state_vector(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2, c
     prefexp = -0.5 * (np.linalg.norm(alpha) ** 2 - alpha @ B @ alpha)
     pref = np.exp(prefexp.conj())
     if post_select is None:
+
+        if extra_args is not None:
+            B = np.diag(extra_args) @ B @ np.diag(extra_args)
+            gamma = extra_args * gamma
+
         psi = np.real_if_close(pref) * hafnian_batched(B.conj(), cutoff, mu=gamma.conj(), renorm=True) / np.sqrt(np.sqrt(np.linalg.det(Q).real))
     else:
         M = N - len(post_select)
@@ -810,17 +815,15 @@ def fock_tensor(S, alpha, cutoff, choi_r=np.arcsinh(1.0), check_symplectic=True,
     x = 2 * alphat.real
     p = 2 * alphat.imag
     mu = np.concatenate([x, p])
-    tensor = state_vector(mu, cov, normalize=False, cutoff=cutoff, hbar=2, check_purity=False)
+    #
+    extra_args = np.concatenate([np.ones([l]), (1.0/np.tanh(choi_r))*np.ones([l])])
+    tensor = state_vector(mu, cov, normalize=False, cutoff=cutoff, hbar=2, check_purity=False, extra_args=extra_args)
 
     vals = list(range(l))
     vals2 = list(range(l, 2 * l))
 
-    R = [1.0 / np.prod((np.tanh(choi_r) ** i) / np.cosh(choi_r)) for i in range(cutoff)]
-    tensor_view = tensor.transpose(vals2 + vals)
-    # There is probably a better way to do the following rescaling, but this is already "good"
-    for p in product(list(range(cutoff)), repeat=l):
-        tensor_view[p] = tensor_view[p] * np.prod([R[i] for i in p])
-
+    R = np.cosh(choi_r)**l
+    tensor = R*tensor
     if sf_order:
         sf_indexing = tuple(chain.from_iterable([[i, i + l] for i in range(l)]))
         return tensor.transpose(sf_indexing)


### PR DESCRIPTION
Improves the numerical stability of the `fock_tensor` function by rescaling the matrix whose batch hafnians are needed. That way one does not need to rescale the value of the matrix elements after they have been calculated. This is done by passing an extra argument to `state_vector`.