### PR TITLE
Update S2gate convention to fit sf

### DIFF
--- a/.github/ACKNOWLEDGMENTS.md
+++ b/.github/ACKNOWLEDGMENTS.md
@@ -35,3 +35,5 @@
 * [J. Eli Bourassa](https://github.com/elib20) (Xanadu, University of Toronto) 🏄 GKP surfer
 
 * [Filippo Miatto](https://github.com/ziofil) (Télécom Paris) 🧝‍♂️ Lord of recursion
+
+* [Theodor Isacsson](https://github.com/thisac) (Xanadu)  :postal_horn: Jarl of contractions

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -27,11 +27,13 @@
 
 * Removes paper.{md,pdf,bib} from the repository now that The Walrus paper is published in Journal of Open Source Software [#106](https://github.com/XanaduAI/thewalrus/pull/106)
 
+* Updates the S2gate to use the correct definition. [#130](https://github.com/XanaduAI/thewalrus/pull/130)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-Josh Izaac, Filippo Miatto, Nicolas Quesada, Trevor Vincent
+Theodor Isacsson, Josh Izaac, Filippo Miatto, Nicolas Quesada, Trevor Vincent
 
 
 ---

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -220,11 +220,11 @@ def grad_S2gate(T, theta, cutoff, dtype=np.complex128):  # pragma: no cover
                 l = m - n + k
                 if 0 <= l < cutoff:
                     gradTtheta[n, k, m, l] = 1j * (n - m) * T[n, k, m, l]
-                    gradTr[n, k, m, l] = -(
+                    gradTr[n, k, m, l] = (
                         np.sqrt((m + 1) * (l + 1)) * T[n, k, m + 1, l + 1] * exptheta
                     )
                     if m > 0 and l > 0:
-                        gradTr[n, k, m, l] += (
+                        gradTr[n, k, m, l] -= (
                             np.sqrt(m * l) * T[n, k, m - 1, l - 1] * np.conj(exptheta)
                         )
     return gradTr, gradTtheta

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -245,7 +245,7 @@ def two_mode_squeezing(r, theta, cutoff, dtype=np.complex128):  # pragma: no cov
 
     """
     sc = 1.0 / np.cosh(r)
-    eiptr = np.exp(-1j * theta) * np.tanh(-r)
+    eiptr = np.exp(-1j * theta) * np.tanh(r)
     R = -np.array(
         [
             [0, -np.conj(eiptr), -sc, 0],

--- a/thewalrus/tests/test_fock_gradients.py
+++ b/thewalrus/tests/test_fock_gradients.py
@@ -248,7 +248,7 @@ def test_S2gate_values(tol):
     theta = 0.7
     cutoff = 5
     T = S2gate(r, theta, cutoff)[0]
-    expected = ((np.tanh(-r) * np.exp(1j * theta)) ** np.arange(cutoff)) / np.cosh(r)
+    expected = ((np.tanh(r) * np.exp(1j * theta)) ** np.arange(cutoff)) / np.cosh(r)
     assert np.allclose(np.diag(T[:, :, 0, 0]), expected, atol=tol, rtol=0)
 
 


### PR DESCRIPTION
**Context:**
The wrong convention was used to implement the two-mode squeezing gate (using a minus instead of a plus between the terms in the definition).

**Description of the Change:**
Changed the argument in the tanh-function for the `two_mode_squeezing` function in `fock_gradients.py` from `-r` to `r` (i.e. removing the `-`).

**Benefits:**
The Strawberry Fields tests now pass, due to the same conventions being used.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
