### PR TITLE
Covariance matrix of the photon number distribution of a Gaussian state

### DIFF
--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -672,7 +672,7 @@ def photon_number_var(mu, cov, j, k, hbar=2):
         cov (array): the covariance matrix of the Gaussian state
         j (int): the first index of the covariance matrix
         k (int): the second index of the covariance matrix
-        hbar (float): the hbar convention used for cov/mu
+        hbar (float): the :math:`hbar` convention used in the commutation relation :math:`[q, p]=i\hbar`
 
     Returns:
         float: the value at index (j, k) of the covariance matrix

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -663,9 +663,9 @@ def photon_number_var(mu, cov, j, k, hbar=2):
     r""" Calculate the variance/covariance of the photon number distribution
     of a Gaussian state.
 
-    Last two eq. of Part II. in 'Multidimensional Hermite polynomials and
+    Last two eq. of Part II. in `'Multidimensional Hermite polynomials and
     photon distribution for polymode mixed light', Dodonov et al.
-    (https://journals.aps.org/pra/abstract/10.1103/PhysRevA.50.813).
+    <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.50.813>`_.
 
     Args:
         mu (array): mean <Q> in ref. above consisting of [q1, q2, ..., qn, p1, p2, ..., pn]

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -85,6 +85,8 @@ Utility functions
     prefactor
     find_scaling_adjacency_matrix
     gen_Qmat_from_graph
+    photon_number_covar
+    photon_number_covmat
     is_valid_cov
     is_pure_cov
     is_classical_cov
@@ -659,23 +661,39 @@ def gen_Qmat_from_graph(A, n_mean):
     return Q
 
 
-def photon_number_var(mu, cov, j, k, hbar=2):
+def photon_number_covar(mu, cov, j, k, hbar=2):
     r""" Calculate the variance/covariance of the photon number distribution
     of a Gaussian state.
 
-    Last two eq. of Part II. in `'Multidimensional Hermite polynomials and
-    photon distribution for polymode mixed light', Dodonov et al.
-    <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.50.813>`_.
+    Implements the covariance matrix of the photon number distribution of a
+    Gaussian state according to the Last two eq. of Part II. in
+    `'Multidimensional Hermite polynomials and photon distribution for polymode
+    mixed light', Dodonov et al. <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.50.813>`_
+
+    .. math::
+        \sigma_{n_j n_j} &= \frac{1}{2}\left(T_j^2 - 2d_j - \frac{1}{2}\right)
+        + \left<\mathbf{Q}_j\right>\mathcal{M}_j\left<\mathbf{Q}_j\right>, \\
+        \sigma_{n_j n_k} &= \frac{1}{2}\mathrm{Tr}\left(\Lambda_j \mathbf{M} \Lambda_k \mathbf{M}\right)
+        + \frac{1}{2}\left<\mathbf{Q}\right>\Lambda_j \mathbf{M} \Lambda_k\left<\mathbf{Q}\right>,
+
+    where :math:`T_j` and :math:`d_j` are the trace and the determinant of
+    :math:`2 \times 2` matrix :math:`\mathcal{M}_j` whose elements coincide
+    with the nonzero elements of matrix :math:`\mathbf{M}_j = \Lambda_j \mathbf{M} \Lambda_k`
+    while the two-vector :math:`\mathbf{Q}_j` has the components :math:`(p_j, q_j)`.
+    :math:`2N \times 2N` projector matrix :math:`\Lambda_j` has only two nonzero
+    elements: :math:`\left(\Lambda_j\right)_{jj} = \left(\Lambda_j\right)_{j+N,j+N} = 1`.
 
     Args:
-        mu (array): vector of means of the Gaussian state using the ordering :math:`[q_1, q_2, \dots, q_n, p_1, p_2, \dots, p_n]`
+        mu (array): vector of means of the Gaussian state using the ordering
+            :math:`[p_1, p_2, \dots, p_n, q_1, q_2, \dots, q_n]`
         cov (array): the covariance matrix of the Gaussian state
-        j (int): the first index of the covariance matrix
-        k (int): the second index of the covariance matrix
-        hbar (float): the :math:`hbar` convention used in the commutation relation :math:`[q, p]=i\hbar`
+        j (int): the j :sup:`th` mode
+        k (int): the k :sup:`th` mode
+        hbar (float): the ``hbar`` convention used in the commutation
+            relation :math:`[p, q]=i\hbar`
 
     Returns:
-        float: the value at index (j, k) of the photon number covariance matrix
+        float: the covariance for the photon numbers at modes :math:`j` and  :math:`k`.
 
     """
     # renormalise the covariance matrix
@@ -708,9 +726,11 @@ def photon_number_covmat(mu, cov, hbar=2):
     Gaussian state.
 
     Args:
-        mu (array): mean <Q> in ref. above consisting of [q1, q2, ..., qn, p1, p2, ..., pn]
-        cov (array): the covariant matrix of the gaussian state
-        hbar (float): the hbar convention used for cov/mu
+        mu (array): vector of means of the Gaussian state using the ordering
+            :math:`[q_1, q_2, \dots, q_n, p_1, p_2, \dots, p_n]`
+        cov (array): the covariance matrix of the Gaussian state
+        hbar (float): the ``hbar`` convention used in the commutation
+            relation :math:`[q, p]=i\hbar`
 
     Returns:
         array: the covariance matrix of the photon number distribution
@@ -720,7 +740,7 @@ def photon_number_covmat(mu, cov, hbar=2):
     pnd_cov = np.zeros((N, N))
     for i in range(N):
         for j in range(N):
-            pnd_cov[i][j] = photon_number_var(mu, cov, i, j, hbar=hbar)
+            pnd_cov[i][j] = photon_number_covar(mu, cov, i, j, hbar=hbar)
     return pnd_cov
 
 

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -668,7 +668,7 @@ def photon_number_var(mu, cov, j, k, hbar=2):
     <https://journals.aps.org/pra/abstract/10.1103/PhysRevA.50.813>`_.
 
     Args:
-        mu (array): mean <Q> in ref. above consisting of [q1, q2, ..., qn, p1, p2, ..., pn]
+        mu (array): vector of means of the Gaussian state using the ordering :math:`[q_1, q_2, \dots, q_n, p_1, p_2, \dots, p_n]`
         cov (array): the covariance matrix of the Gaussian state
         j (int): the first index of the covariance matrix
         k (int): the second index of the covariance matrix

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -694,7 +694,6 @@ def photon_number_covar(mu, cov, j, k, hbar=2):
 
     Returns:
         float: the covariance for the photon numbers at modes :math:`j` and  :math:`k`.
-
     """
     # renormalise the covariance matrix
     cov = cov / hbar
@@ -735,7 +734,6 @@ def photon_number_covmat(mu, cov, hbar=2):
     Returns:
         array: the covariance matrix of the photon number distribution
     """
-
     N = len(mu) // 2
     pnd_cov = np.zeros((N, N))
     for i in range(N):

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -675,7 +675,8 @@ def photon_number_var(mu, cov, j, k, hbar=2):
         hbar (float): the :math:`hbar` convention used in the commutation relation :math:`[q, p]=i\hbar`
 
     Returns:
-        float: the value at index (j, k) of the covariance matrix
+        float: the value at index (j, k) of the photon number covariance matrix
+
     """
     # renormalise the covariance matrix
     cov = cov / hbar

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -669,7 +669,7 @@ def photon_number_var(mu, cov, j, k, hbar=2):
 
     Args:
         mu (array): mean <Q> in ref. above consisting of [q1, q2, ..., qn, p1, p2, ..., pn]
-        cov (array): the covariant matrix of the gaussian state
+        cov (array): the covariance matrix of the Gaussian state
         j (int): the first index of the covariance matrix
         k (int): the second index of the covariance matrix
         hbar (float): the hbar convention used for cov/mu

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -35,6 +35,7 @@ from thewalrus.quantum import (
     Covmat,
     gen_Qmat_from_graph,
     Means,
+    photon_number_covmat,
     is_valid_cov,
     is_pure_cov,
     pure_state_amplitude,
@@ -833,3 +834,69 @@ def test_sf_ordering_in_fock_tensor(tol):
     T = fock_tensor(S, alphas, cutoff)
     Tsf = fock_tensor(S, alphas, cutoff, sf_order=True)
     assert np.allclose(T.transpose([0, 2, 1, 3]), Tsf, atol=tol, rtol=0)
+
+
+LIST_FUNCS = [np.zeros, np.ones, np.arange]
+
+@pytest.mark.parametrize("list_func", LIST_FUNCS)
+@pytest.mark.parametrize("N", [1, 2, 4])
+@pytest.mark.parametrize("hbar", [1, 2])
+def test_pnd_coherent_state(tol, list_func, N, hbar):
+    r"""Test the covariance matrix :math:`\frac{\hbar}{2} \mathbb{I}`."""
+    cov = np.eye(2 * N) * hbar / 2
+    mu = list_func(2 * N)
+
+    pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
+    alpha = (mu[:N] ** 2 + mu[N:] ** 2) / (2 * hbar)
+
+    assert np.allclose(pnd_cov, np.diag(alpha), atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("r", np.linspace(0, 2, 4))
+@pytest.mark.parametrize("phi", np.linspace(0, np.pi, 4))
+@pytest.mark.parametrize("hbar", [1, 2])
+def test_pnd_two_mode_squeeze_vacuum(tol, r, phi, hbar):
+    """Test the photon number distribution for the two-mode squeezed vacuum"""
+    S = two_mode_squeezing(r, phi)
+    mu = np.zeros(4)
+
+    cov = hbar / 2 * (S @ S.T)
+    pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
+    n = np.sinh(r) ** 2
+
+    assert np.allclose(pnd_cov, np.full((2, 2), n ** 2 + n), atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("n", np.linspace(0, 10, 4))
+@pytest.mark.parametrize("N", [1, 2, 4])
+@pytest.mark.parametrize("hbar", [1, 2])
+def test_pnd_thermal(tol, n, N, hbar):
+    """Test the photon number distribution for thermal states"""
+    cov = np.eye(2 * N) * hbar / 2 * (2 * n + 1)
+    mu = np.zeros(2 * N)
+    pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
+
+    assert np.allclose(pnd_cov, np.diag([n ** 2 + n] * N), atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("r", np.linspace(0, 2, 4))
+@pytest.mark.parametrize("phi", np.linspace(0, np.pi, 4))
+@pytest.mark.parametrize("alpha", [0, 1.0, 1j, 1.0 + 1j])
+@pytest.mark.parametrize("hbar", [1, 2])
+def test_pnd_squeeze_displace(tol, r, phi, alpha, hbar):
+    """Test the photon number distribution for the squeezed displaced state
+
+    Eq. (17) in 'Benchmarking of Gaussian boson sampling using two-point correlators',
+    Phillips et al. (https://ris.utwente.nl/ws/files/122721825/PhysRevA.99.023836.pdf).
+    """
+    S = squeezing(r, phi)
+    mu = [np.sqrt(2 * hbar) * np.real(alpha), np.sqrt(2 * hbar) * np.imag(alpha)]
+
+    cov = hbar / 2 * (S @ S.T)
+    pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
+
+    pnd_cov_analytic = np.sinh(r) ** 2 * np.cosh(r) ** 2 + np.sinh(r) ** 4 \
+        + np.sinh(r) ** 2 + np.abs(alpha) ** 2 * (1 + 2 * np.sinh(r) ** 2) \
+        - 2 * np.real(alpha ** 2 * np.exp(-1j * phi) * np.sinh(r) * np.cosh(r))
+
+    assert np.isclose(float(pnd_cov), pnd_cov_analytic, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**
It would be useful to implement the covariance matrix of the photon number distribution of a Gaussian state.

**Description of the Change:**
A function is added that implements the covariance matrix of the photon number distribution of a Gaussian state according to the last two eq. of Part II. in 'Multidimensional Hermite polynomials and photon distribution for polymode mixed light', Dodonov et al. (https://journals.aps.org/pra/abstract/10.1103/PhysRevA.50.813).

![Screenshot from 2020-02-26 16-11-01](https://user-images.githubusercontent.com/6934626/75388516-261c4a80-58b3-11ea-8c3f-7f4ee0adc9a8.png)

where T<sub>j</sub> and d<sub>j</sub> are the trace and the determinant of the 2x2 matrix M<sub>j</sub>, in the first of the two eq. above, which consists of the nonzero elements of the _l_<sub>j</sub> **M** _l_<sub>k</sub> (where _l_ is _lambda_), and the vector **Q**<sub>j</sub> = (_p_<sub>j</sub>, _q_<sub>j</sub>) and (_l_<sub>j</sub>)<sub>jj</sub> = (_l_<sub>j</sub>)<sub>j+N,j+N</sub> = 1. See reference for details.

**Benefits:**
The Walrus now has a nice function that calculates the covariance matrix of the photon number distribution of a Gaussian state.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
Closes #109 