### PR TITLE
Bump version to 0.12.0-dev

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Version 0.12.0-dev
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+
+
+
+---
+
+
 # Version 0.11.0
 
 ### New features

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,7 +21,7 @@
 #define HAFNIAN_VERSION_MAJOR 0
 
 /// The minor version number
-#define HAFNIAN_VERSION_MINOR 11
+#define HAFNIAN_VERSION_MINOR 12
 
 /// The patch number
 #define HAFNIAN_VERSION_PATCH 0
@@ -30,4 +30,4 @@
 #define HAFNIAN_VERSION_CODE (HAFNIAN_VERSION_MAJOR * 10000 + HAFNIAN_VERSION_MINOR * 100 + HAFNIAN_VERSION_PATCH)
 
 /// Version number as string
-#define HAFNIAN_VERSION_STRING "0.11.0"
+#define HAFNIAN_VERSION_STRING "0.12.0"

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0-dev"


### PR DESCRIPTION
**Context:**
After the release of 0.11.0, bump the version to 0.12.0-dev.

**Description of the Change:**
Increment the version number to 0.12.0-dev.

**Benefits:**
New version to work on.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None