### PR TITLE
Add dask for parallelisation of samples

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Improvements
 
+* Implements parallelization with Dask for sampling from the Hafnian/Torontonian of a Gaussian state. [#145](https://github.com/XanaduAI/thewalrus/pull/145)
+
 ### Bug fixes
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-
+Theodor Isacsson
 
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.13.3
 scipy>=1.2.1
 numba>=0.43.1
 cython
+dask[delayed]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ with open("thewalrus/_version.py") as f:
 requirements = [
     "numpy",
     "scipy>=1.2.1",
-    "numba>=0.43.1"
+    "numba>=0.43.1",
+    "dask[delayed]"
 ]
 
 

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -44,9 +44,6 @@ Code details
 ------------
 """
 # pylint: disable=too-many-arguments
-import multiprocessing
-from multiprocessing import Pool
-
 import numpy as np
 from scipy.special import factorial as fac
 
@@ -233,7 +230,7 @@ def hafnian_sample_state(
     max_photons=30,
     approx=False,
     approx_samples=1e5,
-    pool=False,
+    parallel=False,
 ):
     r"""Returns samples from the Hafnian of a Gaussian state.
 
@@ -252,42 +249,38 @@ def hafnian_sample_state(
             to approximate the hafnian. Note that this can only be used for
             real, non-negative matrices.
         approx_samples: the number of samples used to approximate the hafnian if ``approx=True``.
-        pool (bool): if ``True``, uses ``multiprocessor.Pool`` for parallelization of samples
+        parallel (bool): if ``True``, uses ``dask`` for parallelization of samples
 
     Returns:
         np.array[int]: photon number samples from the Gaussian state
     """
-    if not pool:
-        params = [cov, samples, mean, hbar, cutoff, max_photons, approx, approx_samples]
-        return _hafnian_sample(params)
+    # pylint: disable=import-outside-toplevel
+    if parallel:
+        try:
+            import dask
+        except:
+            raise ImportError(
+                "Dask must be installed for parallel evaluation. "
+                "\nDask can be installed using pip:"
+                "\n\npip install dask[delayed]"
+            )
 
-    pool = Pool()
-    nprocs = multiprocessing.cpu_count()
-    localsamps = samples // nprocs
+        params = [[cov, 1, mean, hbar, cutoff, max_photons, approx, approx_samples]] * samples
+        compute_list = []
+        for p in params:
+            compute_list.append(dask.delayed(_hafnian_sample)(p))
 
-    params = [[cov, localsamps, mean, hbar, cutoff, max_photons, approx, approx_samples]] * (nprocs - 1)
-    params.append(
-        [
-            cov,
-            samples - localsamps * (nprocs - 1),
-            mean,
-            hbar,
-            cutoff,
-            max_photons,
-            approx,
-            approx_samples,
-        ]
-    )
+        results = dask.compute(*compute_list, scheduler="threads")
 
-    result = np.vstack(pool.map(_hafnian_sample, params))
-    pool.close()  # no more tasks
-    pool.join()  # wrap up current tasks
+        return np.vstack(results)
 
-    return result
+    params = [cov, samples, mean, hbar, cutoff, max_photons, approx, approx_samples]
+    return _hafnian_sample(params)
+
 
 
 def hafnian_sample_graph(
-    A, n_mean, samples=1, cutoff=5, max_photons=30, approx=False, approx_samples=1e5, pool=False
+    A, n_mean, samples=1, cutoff=5, max_photons=30, approx=False, approx_samples=1e5, parallel=False
 ):
     r"""Returns samples from the Gaussian state specified by the adjacency matrix :math:`A`
     and with total mean photon number :math:`n_{mean}`
@@ -301,7 +294,7 @@ def hafnian_sample_graph(
         approx (bool): if ``True``, the approximate hafnian algorithm is used.
             Note that this can only be used for real, non-negative matrices.
         approx_samples: the number of samples used to approximate the hafnian if ``approx=True``.
-        pool (bool): if ``True``, uses ``multiprocessor.Pool`` for parallelization of samples
+        parallel (bool): if ``True``, uses ``dask`` for parallelization of samples
 
     Returns:
         np.array[int]: photon number samples from the Gaussian state
@@ -317,7 +310,7 @@ def hafnian_sample_graph(
         max_photons=max_photons,
         approx=approx,
         approx_samples=approx_samples,
-        pool=pool,
+        parallel=parallel,
     )
 
 
@@ -439,7 +432,7 @@ def _torontonian_sample(args):
     return np.vstack(samples_array)
 
 
-def torontonian_sample_state(cov, samples, hbar=2, max_photons=30, pool=False):
+def torontonian_sample_state(cov, samples, hbar=2, max_photons=30, parallel=False):
     r"""Returns samples from the Torontonian of a Gaussian state
 
     Args:
@@ -450,30 +443,37 @@ def torontonian_sample_state(cov, samples, hbar=2, max_photons=30, pool=False):
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`.
         max_photons (int): specifies the maximum number of clicks that can be counted.
-        pool (boolean): if ``True``, uses ``multiprocessor.Pool`` for parallelization of samples
+        parallel (bool): if ``True``, uses ``dask`` for parallelization of samples
 
     Returns:
         np.array[int]:  threshold samples from the Gaussian state.
     """
-    if not pool:
-        params = [cov, samples, hbar, max_photons]
-        return _torontonian_sample(params)
+    # pylint: disable=import-outside-toplevel
+    if parallel:
+        try:
+            import dask
+        except:
+            raise ImportError(
+                "Dask must be installed for parallel evaluation. "
+                "\nDask can be installed using pip:"
+                "\n\npip install dask[delayed]"
+            )
 
-    pool = Pool()
-    nprocs = multiprocessing.cpu_count()
-    localsamps = samples // nprocs
+        params = [[cov, 1, hbar, max_photons]] * samples
+        compute_list = []
+        for p in params:
+            compute_list.append(dask.delayed(_torontonian_sample)(p))
 
-    params = [[cov, localsamps, hbar, max_photons]] * (nprocs - 1)
-    params.append([cov, samples - localsamps * (nprocs - 1), hbar, max_photons])
+        results = dask.compute(*compute_list, scheduler="threads")
 
-    result = np.vstack(pool.map(_torontonian_sample, params))
-    pool.close()  # no more tasks
-    pool.join()  # wrap up current tasks
+        return np.vstack(results)
 
-    return result
+    params = [cov, samples, hbar, max_photons]
+    return _torontonian_sample(params)
 
 
-def torontonian_sample_graph(A, n_mean, samples=1, max_photons=30, pool=False):
+
+def torontonian_sample_graph(A, n_mean, samples=1, max_photons=30, parallel=False):
     r"""Returns samples from the Torontonian of a Gaussian state specified by the adjacency matrix :math:`A`
     and with total mean photon number :math:`n_{mean}`
 
@@ -482,14 +482,14 @@ def torontonian_sample_graph(A, n_mean, samples=1, max_photons=30, pool=False):
         n_mean (float): mean photon number of the Gaussian state
         samples (int): the number of samples to return.
         max_photons (int): specifies the maximum number of photons that can be counted.
-        pool (boolean): if ``True``, uses ``multiprocessor.Pool`` for parallelization of samples
+        parallel (bool): if ``True``, uses ``dask`` for parallelization of samples
 
     Returns:
         np.array[int]: photon number samples from the Torontonian of the Gaussian state
     """
     Q = gen_Qmat_from_graph(A, n_mean)
     cov = Covmat(Q)
-    return torontonian_sample_state(cov, samples, hbar=2, max_photons=max_photons, pool=pool)
+    return torontonian_sample_state(cov, samples, hbar=2, max_photons=max_photons, parallel=parallel)
 
 
 # pylint: disable=unused-argument

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -140,7 +140,7 @@ def generate_hafnian_sample(
         result.append(np.random.choice(a=range(len(probs3)), p=probs3))
         if result[-1] == cutoff:
             return -1
-        if sum(result) > max_photons:
+        if np.sum(result) > max_photons:
             return -1
         prev_prob = probs1[result[-1]]
 
@@ -364,7 +364,7 @@ def generate_torontonian_sample(cov, hbar=2, max_photons=30):
 
         prev_prob = probs1a[result[-1]]
 
-        if np.sum(result) >= max_photons:
+        if np.sum(result) > max_photons:
             return -1
 
     return result

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -44,6 +44,7 @@ Code details
 ------------
 """
 # pylint: disable=too-many-arguments
+import dask
 import numpy as np
 from scipy.special import factorial as fac
 
@@ -254,17 +255,7 @@ def hafnian_sample_state(
     Returns:
         np.array[int]: photon number samples from the Gaussian state
     """
-    # pylint: disable=import-outside-toplevel
     if parallel:
-        try:
-            import dask
-        except:
-            raise ImportError(
-                "Dask must be installed for parallel evaluation. "
-                "\nDask can be installed using pip:"
-                "\n\npip install dask[delayed]"
-            )
-
         params = [[cov, 1, mean, hbar, cutoff, max_photons, approx, approx_samples]] * samples
         compute_list = []
         for p in params:
@@ -448,17 +439,7 @@ def torontonian_sample_state(cov, samples, hbar=2, max_photons=30, parallel=Fals
     Returns:
         np.array[int]:  threshold samples from the Gaussian state.
     """
-    # pylint: disable=import-outside-toplevel
     if parallel:
-        try:
-            import dask
-        except:
-            raise ImportError(
-                "Dask must be installed for parallel evaluation. "
-                "\nDask can be installed using pip:"
-                "\n\npip install dask[delayed]"
-            )
-
         params = [[cov, 1, hbar, max_photons]] * samples
         compute_list = []
         for p in params:

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -443,9 +443,6 @@ class TestTorontonianSampling:
         assert np.all(samples[:, 0] == samples[:, 1])
 
 
-# def test_max_photons
-
-
 def test_seed():
     """Tests that seed method does reset the random number generators"""
     n_samples = 10

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -57,6 +57,15 @@ def TMS_cov(r, phi):
 class TestHafnianSampling:
     """Tests for hafnian sampling"""
 
+    @pytest.mark.parametrize("max_photons", [10, 2, 0])
+    def test_hafnian_state_lowmax(self, max_photons):
+        """test sampling never exceeds max photons for hafnian"""
+        m = 0.432
+        phi = 0.546
+        V = TMS_cov(np.arcsinh(m), phi)
+        res = hafnian_sample_state(V, samples=10, max_photons=max_photons)
+        assert np.max(res) <= max_photons
+
     def test_TMS_hafnian_sample_states(self):
         """test sampling from TMS hafnians is correlated"""
         m = 0.432
@@ -317,6 +326,15 @@ class TestHafnianSampling:
 class TestTorontonianSampling:
     """Tests for torontonian sampling"""
 
+    @pytest.mark.parametrize("max_photons", [10, 2, 0])
+    def test_torontonian_state_lowmax(self, max_photons):
+        """test sampling never exceeds max photons for torontonian"""
+        m = 0.432
+        phi = 0.546
+        V = TMS_cov(np.arcsinh(m), phi)
+        res = torontonian_sample_state(V, samples=10, max_photons=max_photons)
+        assert np.max(res) <= max_photons
+
     def test_torontonian_samples_nonnumpy(self):
         """test exception is raised if not a numpy array"""
         with pytest.raises(TypeError):
@@ -423,6 +441,9 @@ class TestTorontonianSampling:
         mean_n = 0.5
         samples = torontonian_sample_graph(A, mean_n, samples=n_samples, parallel=parallel)
         assert np.all(samples[:, 0] == samples[:, 1])
+
+
+# def test_max_photons
 
 
 def test_seed():

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -229,7 +229,8 @@ class TestHafnianSampling:
         approx_mean_n = np.sum(samples) / n_samples
         assert np.allclose(mean_n, approx_mean_n, rtol=2e-1)
 
-    def test_single_pm_graphs(self):
+    @pytest.mark.parametrize("parallel", [True, False])
+    def test_single_pm_graphs(self, parallel):
         """Tests that the number of photons is the same for modes i and n-i
         in the special case of a graph with one single perfect matching
         """
@@ -238,9 +239,8 @@ class TestHafnianSampling:
         A = np.eye(n)[::-1]
         n_mean = 2
         nr_samples = 10
-        pool = False
         samples = hafnian_sample_graph(
-            A, n_mean, cutoff=5, approx=True, approx_samples=approx_samples, samples=nr_samples, pool=pool
+            A, n_mean, cutoff=5, approx=True, approx_samples=approx_samples, samples=nr_samples, parallel=parallel
         )
 
         test_passed = True
@@ -415,14 +415,13 @@ class TestTorontonianSampling:
         probs[1] = 1 - probs[0]
         assert np.all(np.abs(rel_freq - probs) < rel_tol / np.sqrt(n_samples))
 
-    def test_torontonian_sample_graph(self):
+    @pytest.mark.parametrize("parallel", [True, False])
+    def test_torontonian_sample_graph(self, parallel):
         """Test torontonian sampling from a graph"""
-        # Pool does not play nicely with pytest when all the test are run together
         A = np.array([[0, 3.0 + 4j], [3.0 + 4j, 0]])
         n_samples = 1000
         mean_n = 0.5
-        pool = False
-        samples = torontonian_sample_graph(A, mean_n, samples=n_samples, pool=pool)
+        samples = torontonian_sample_graph(A, mean_n, samples=n_samples, parallel=parallel)
         assert np.all(samples[:, 0] == samples[:, 1])
 
 


### PR DESCRIPTION
**Context:**
The current parallelisation scheme doesn't work well with pytest (it freezes when running all tests). Thus, no tests are run for the particular case when parallelisation was used.

By using a library called Dask pytest can run without any issues or freezes.

**Description of the Change:**
Dask has been implemented as the parallelisation engine in the two sampling functions ``hafnian_sample_state`` and ``torontonian_sample_state`` instead of using ``multiprocessing.Pool``.

The tests have been changed to run for both ``parallel=True`` and ``parallel=False``.

**Benefits:**
Parallelisation is fully tested since pytest can run without any issues or freezes.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A