### PR TITLE
Brute force samplers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 * Adds the ability to calculate the mean number of photons in a given mode of a Gaussian state. [#148](https://github.com/XanaduAI/thewalrus/pull/148)
 
+* Adds the ability to calculate the photon number distribution of a pure state or mixed state using `generate_probabilities`. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
+
+* Allows to update the photon number distirbution when undergoing loss by using `update_probabilities_with_loss`. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
+
+* Adds a brute force sampler `photon_number_sampler` that given a (multi-)mode photon number distribution generates photon number samples. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
+
 ### Improvements
 
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 * Adds the ability to calculate the mean number of photons in a given mode of a Gaussian state. [#148](https://github.com/XanaduAI/thewalrus/pull/148)
 
-* Adds the ability to calculate the photon number distribution of a pure state or mixed state using `generate_probabilities`. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
+* Adds the ability to calculate the photon number distribution of a pure or mixed state using `generate_probabilities`. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
 
-* Allows to update the photon number distirbution when undergoing loss by using `update_probabilities_with_loss`. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
+* Allows to update the photon number distribution when undergoing loss by using `update_probabilities_with_loss`. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
 
 * Adds a brute force sampler `photon_number_sampler` that given a (multi-)mode photon number distribution generates photon number samples. [#152](https://github.com/XanaduAI/thewalrus/pull/152)
 

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1117,7 +1117,7 @@ def update_probabilities_with_loss(etas, probs):
     an updated tensor of probabilities after loss is applied.
 
     Args:
-        etas (list): List of transmission descrbing the loss in each of the modes
+        etas (list): List of transmission describing the loss in each of the modes
         probs (array): Array of probabilitites in the different modes
 
     Returns:

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1063,7 +1063,7 @@ def fock_tensor(S, alpha, cutoff, choi_r=np.arcsinh(1.0), check_symplectic=True,
 
 def generate_probabilities(mu, cov, cutoff, hbar=2.0):
     """ Generate the Fock space probabilities of Gaussian state with vector of mean
-    mu and covariance matrix cov up Fock space cutoff.
+    mu and covariance matrix cov up to Fock space cutoff.
 
     Args:
         mu (array): vector of means of length 2*n_modes
@@ -1075,7 +1075,7 @@ def generate_probabilities(mu, cov, cutoff, hbar=2.0):
         (array): Fock space probabilities up to cutoff. The shape of this tensor is [cutoff]*num_modes
     """
     if is_pure_cov(cov, hbar=hbar):  # Check if the covariance matrix cov is pure
-        return np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar)) ** 2
+        return np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar, check_purity=False)) ** 2
     num_modes = len(mu) // 2
     probabilities = np.zeros([cutoff] * num_modes)
     for i in product(range(cutoff), repeat=num_modes):
@@ -1117,7 +1117,7 @@ def loss_mat(eta, cutoff):
 
 
 def update_probabilities_with_loss(etas, probs):
-    """ Give a list of transmissivities etas and a tensor of probabilitites probs it calculates
+    """ Given a list of transmissivities etas and a tensor of probabilitites probs it calculates
     an updated tensor of probabilities after loss is applied.
 
     Args:

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1087,7 +1087,7 @@ def generate_probabilities(mu, cov, cutoff, hbar=2.0):
 
 
 @jit(nopython=True)
-def loss_mat(eta, cutoff):
+def loss_mat(eta, cutoff): # pragma: no cover
     """ Constructs a binomial loss matrix with transmission eta up to n photons.
 
     Args:

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1076,13 +1076,13 @@ def probabilities(mu, cov, cutoff, hbar=2.0):
     if is_pure_cov(cov, hbar=hbar):  # Check if the covariance matrix cov is pure
         return np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar, check_purity=False)) ** 2
     num_modes = len(mu) // 2
-    probabilities = np.zeros([cutoff] * num_modes)
+    probs = np.zeros([cutoff] * num_modes)
     for i in product(range(cutoff), repeat=num_modes):
-        probabilities[i] = np.maximum(
+        probs[i] = np.maximum(
             0.0, np.real_if_close(density_matrix_element(mu, cov, i, i, hbar=hbar))
         )
         # The maximum is needed because every now and then a probability is very close to zero from below.
-    return probabilities
+    return probs
 
 
 @jit(nopython=True)

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -51,6 +51,7 @@ Fock states and tensors
     density_matrix
     fock_tensor
     generate_probabilities
+    update_probabilities_with_loss
 
 Details
 ^^^^^^^
@@ -72,6 +73,9 @@ Details
 
 .. autofunction::
     generate_probabilities
+
+.. autofunction::
+    update_probabilities_with_loss
 
 Utility functions
 -----------------

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1105,15 +1105,15 @@ def loss_mat(eta, cutoff):
 
     if eta == 1.0:
         return np.identity(cutoff)
-    else:
-        # Otherwise construct the matrix elements recursively
-        lm = np.zeros((cutoff, cutoff))
-        mu = 1.0 - eta
-        lm[:, 0] = mu ** (np.arange(cutoff))
-        for i in range(cutoff):
-            for j in range(1, i + 1):
-                lm[i, j] = lm[i, j - 1] * (eta / mu) * (i - j + 1) / (j)
-        return lm
+
+    # Otherwise construct the matrix elements recursively
+    lm = np.zeros((cutoff, cutoff))
+    mu = 1.0 - eta
+    lm[:, 0] = mu ** (np.arange(cutoff))
+    for i in range(cutoff):
+        for j in range(1, i + 1):
+            lm[i, j] = lm[i, j - 1] * (eta / mu) * (i - j + 1) / (j)
+    return lm
 
 
 def update_probabilities_with_loss(etas, probs):

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1095,7 +1095,8 @@ def loss_mat(eta, cutoff): # pragma: no cover
         n (int): photon number cutoff.
 
     Returns:
-        array: `n\times n` matrix representing the loss.
+        array: :math:`n\times n` matrix representing the loss.
+
 
     """
     # If full transmission return the identity

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1062,17 +1062,18 @@ def fock_tensor(S, alpha, cutoff, choi_r=np.arcsinh(1.0), check_symplectic=True,
 
 
 def generate_probabilities(mu, cov, cutoff, hbar=2.0):
-    """ Generate the Fock space probabilities of Gaussian state with vector of mean
-    mu and covariance matrix cov up to Fock space cutoff.
+    """Generate the Fock space probabilities of a Gaussian state up to a Fock space cutoff.
 
     Args:
-        mu (array): vector of means of length 2*n_modes
-        cov (array): covariance matrix of shape [2*n_modes, 2*n_modes]
+        mu (array): vector of means of length ``2*n_modes``
+
+        cov (array): covariance matrix of shape ``[2*n_modes, 2*n_modes]``
+
         cutoff (int): Fock space cutoff
-        hbar (float): value of hbar
+        hbar (float): value of :math:`\hbar` in the commutation relation :math;`[\hat{x}, \hat{p}]=i\hbar`
 
     Returns:
-        (array): Fock space probabilities up to cutoff. The shape of this tensor is [cutoff]*num_modes
+        (array): Fock space probabilities up to cutoff. The shape of this tensor is ``[cutoff]*num_modes``.
     """
     if is_pure_cov(cov, hbar=hbar):  # Check if the covariance matrix cov is pure
         return np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar, check_purity=False)) ** 2
@@ -1088,16 +1089,15 @@ def generate_probabilities(mu, cov, cutoff, hbar=2.0):
 
 @jit(nopython=True)
 def loss_mat(eta, cutoff): # pragma: no cover
-    """ Constructs a binomial loss matrix with transmission eta up to n photons.
+    """Constructs a binomial loss matrix with transmission eta up to n photons.
 
     Args:
-        eta (float): Transmission coefficient. eta=0.0 means complete loss and eta=1.0 means no loss.
+        eta (float): Transmission coefficient. ``eta=0.0`` corresponds to complete loss and ``eta=1.0`` corresponds to no loss.
+
         n (int): photon number cutoff.
 
     Returns:
         array: :math:`n\times n` matrix representing the loss.
-
-
     """
     # If full transmission return the identity
 
@@ -1118,16 +1118,15 @@ def loss_mat(eta, cutoff): # pragma: no cover
 
 
 def update_probabilities_with_loss(etas, probs):
-    """ Given a list of transmissivities etas and a tensor of probabilitites probs it calculates
+    """Given a list of transmissivities a tensor of probabilitites, calculate
     an updated tensor of probabilities after loss is applied.
 
     Args:
-        etas (list): List of transmission describing the loss in each of the modes
+        etas (list): List of transmissitivities describing the loss in each of the modes
         probs (array): Array of probabilitites in the different modes
 
     Returns:
         array: List of loss-updated probabilities.
-
     """
 
     probs_shape = probs.shape

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -50,7 +50,7 @@ Fock states and tensors
     density_matrix_element
     density_matrix
     fock_tensor
-    generate_probabilities
+    probabilities
     update_probabilities_with_loss
 
 Details
@@ -72,7 +72,7 @@ Details
     fock_tensor
 
 .. autofunction::
-    generate_probabilities
+    probabilities
 
 .. autofunction::
     update_probabilities_with_loss
@@ -1061,15 +1061,13 @@ def fock_tensor(S, alpha, cutoff, choi_r=np.arcsinh(1.0), check_symplectic=True,
     return tensor
 
 
-def generate_probabilities(mu, cov, cutoff, hbar=2.0):
-    """Generate the Fock space probabilities of a Gaussian state up to a Fock space cutoff.
+def probabilities(mu, cov, cutoff, hbar=2.0):
+    r"""Generate the Fock space probabilities of a Gaussian state up to a Fock space cutoff.
 
     Args:
         mu (array): vector of means of length ``2*n_modes``
-
         cov (array): covariance matrix of shape ``[2*n_modes, 2*n_modes]``
-
-        cutoff (int): Fock space cutoff
+        cutoff (int): cutoff in Fock space
         hbar (float): value of :math:`\hbar` in the commutation relation :math;`[\hat{x}, \hat{p}]=i\hbar`
 
     Returns:
@@ -1089,12 +1087,11 @@ def generate_probabilities(mu, cov, cutoff, hbar=2.0):
 
 @jit(nopython=True)
 def loss_mat(eta, cutoff): # pragma: no cover
-    """Constructs a binomial loss matrix with transmission eta up to n photons.
+    r"""Constructs a binomial loss matrix with transmission eta up to n photons.
 
     Args:
         eta (float): Transmission coefficient. ``eta=0.0`` corresponds to complete loss and ``eta=1.0`` corresponds to no loss.
-
-        n (int): photon number cutoff.
+        cutoff (int): cutoff in Fock space.
 
     Returns:
         array: :math:`n\times n` matrix representing the loss.
@@ -1126,7 +1123,7 @@ def update_probabilities_with_loss(etas, probs):
         probs (array): Array of probabilitites in the different modes
 
     Returns:
-        array: List of loss-updated probabilities.
+        array: List of loss-updated probabilities with the same shape as probs.
     """
 
     probs_shape = probs.shape

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -538,6 +538,7 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
 
 def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
     """ Given a photon-number probability mass function(PMF) it returns samples according to said PMF.
+
     Args:
         probabilities (array): probability tensor of the modes, has shape [cutoff]*num_modes
         num_samples (int): number of samples requested

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -537,13 +537,13 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
 
 
 def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
-    """ Given a photon-number probability mass function(PMF) it returns samples according to said PMF.
+    """Given a photon-number probability mass function(PMF) it returns samples according to said PMF.
 
     Args:
-        probabilities (array): probability tensor of the modes, has shape [cutoff]*num_modes
+        probabilities (array): probability tensor of the modes, has shape ``[cutoff]*num_modes``
         num_samples (int): number of samples requested
-        out_of_bounds (boolean): if False it renormalizes the probability distribution. If not False it returns
-            out_of_bounds as place holder for samples where more than the cutoff of probabilities are detected.
+        out_of_bounds (boolean): if ``False`` the probability distribution is renormalized. If not ``False``, the value of
+            ``out_of_bounds`` is used as a placeholder for samples where more than the cutoff of probabilities are detected.
 
     Returns:
         (array): Samples, with shape [num_sample, num_modes]

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -40,6 +40,12 @@ Torontonian sampling
     torontonian_sample_graph
     torontonian_sample_classical_state
 
+Brute force sampling
+--------------------
+
+.. autosummary::
+    photon_number_sampler
+
 Code details
 ------------
 """

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -571,6 +571,7 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
     probabilities = np.append(probabilities.flatten(), 1.0 - sum_p)
     return [sorter(np.random.choice(vals, p=probabilities)) for _ in range(num_samples)]
 
+
 def seed(seed_val=None):
     r""" Seeds the random number generator used in the sampling algorithms.
 

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -550,7 +550,7 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
     cutoff = probabilities.shape[0]
     sum_p = np.sum(probabilities)
 
-    if renorm is False:
+    if out_of_bounds is False:
         probabilities = probabilities.flatten() / sum_p
         vals = np.arange(cutoff**num_modes, dtype=int)
         return [

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -541,7 +541,7 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
     Args:
         probabilities (array): probability tensor of the modes, has shape [cutoff]*num_modes
         num_samples (int): number of samples requested
-        out_of_bounds (boolean): if False is renormalizes the probability distribution. If not False it returns
+        out_of_bounds (boolean): if False it renormalizes the probability distribution. If not False it returns
             out_of_bounds as place holder for samples where more than the cutoff of probabilities are detected.
     Returns
         (array): Samples, with shape [num_sample, num_modes]

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -530,6 +530,43 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
     )
 
 
+def photon_number_sampler(probabilities, num_samples, renorm=True, out_of_bounds=False):
+    """ Given a photon-number probability mass function(PMF) it returns samples according to said PMF.
+    Args:
+        probabilities (array): probability tensor of the modes, has shape [cutoff]*num_modes
+        num_samples (int): number of samples requested
+    Returns
+        (array): Samples, with shape [num_sample, num_modes]
+    """
+    if (renorm is True and out_of_bounds is not False) or (renorm is False and out_of_bounds is False):
+        raise ValueError("One and only one of renorm and out_of_bounds can be False")
+
+    num_modes = len(probabilities.shape)
+    cutoff = probabilities.shape[0]
+    sum_p = np.sum(probabilities)
+
+    if renorm is True:
+        probabilities = probabilities.flatten() / sum_p
+        vals = np.arange(cutoff**num_modes, dtype=int)
+        return [
+            np.unravel_index(np.random.choice(vals, p=probabilities), [cutoff] * num_modes)
+            for _ in range(num_samples)
+            ]
+
+    if out_of_bounds is not False:
+
+        upper_limit = cutoff ** num_modes
+
+        def sorter(index):
+            if index == upper_limit:
+                return out_of_bounds
+            else:
+                return np.unravel_index(index, [cutoff] * num_modes)
+
+        vals = np.arange(1 + cutoff**num_modes, dtype=int)
+        probabilities = np.append(probabilities.flatten(), 1.0 - sum_p)
+        return [sorter(np.random.choice(vals, p=probabilities)) for _ in range(num_samples)]
+
 def seed(seed_val=None):
     r""" Seeds the random number generator used in the sampling algorithms.
 

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -536,22 +536,21 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
     )
 
 
-def photon_number_sampler(probabilities, num_samples, renorm=True, out_of_bounds=False):
+def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
     """ Given a photon-number probability mass function(PMF) it returns samples according to said PMF.
     Args:
         probabilities (array): probability tensor of the modes, has shape [cutoff]*num_modes
         num_samples (int): number of samples requested
+        out_of_bounds (boolean): if False is renormalizes the probability distribution. If not False it returns
+            out_of_bounds as place holder for samples where more than the cutoff of probabilities are detected.
     Returns
         (array): Samples, with shape [num_sample, num_modes]
     """
-    if (renorm is True and out_of_bounds is not False) or (renorm is False and out_of_bounds is False):
-        raise ValueError("One and only one of renorm and out_of_bounds can be False")
-
     num_modes = len(probabilities.shape)
     cutoff = probabilities.shape[0]
     sum_p = np.sum(probabilities)
 
-    if renorm is True:
+    if renorm is False:
         probabilities = probabilities.flatten() / sum_p
         vals = np.arange(cutoff**num_modes, dtype=int)
         return [
@@ -559,19 +558,17 @@ def photon_number_sampler(probabilities, num_samples, renorm=True, out_of_bounds
             for _ in range(num_samples)
             ]
 
-    if out_of_bounds is not False:
+    upper_limit = cutoff ** num_modes
 
-        upper_limit = cutoff ** num_modes
+    def sorter(index):
+        if index == upper_limit:
+            return out_of_bounds
 
-        def sorter(index):
-            if index == upper_limit:
-                return out_of_bounds
-            else:
-                return np.unravel_index(index, [cutoff] * num_modes)
+        return np.unravel_index(index, [cutoff] * num_modes)
 
-        vals = np.arange(1 + cutoff**num_modes, dtype=int)
-        probabilities = np.append(probabilities.flatten(), 1.0 - sum_p)
-        return [sorter(np.random.choice(vals, p=probabilities)) for _ in range(num_samples)]
+    vals = np.arange(1 + cutoff**num_modes, dtype=int)
+    probabilities = np.append(probabilities.flatten(), 1.0 - sum_p)
+    return [sorter(np.random.choice(vals, p=probabilities)) for _ in range(num_samples)]
 
 def seed(seed_val=None):
     r""" Seeds the random number generator used in the sampling algorithms.

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -543,7 +543,8 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
         num_samples (int): number of samples requested
         out_of_bounds (boolean): if False it renormalizes the probability distribution. If not False it returns
             out_of_bounds as place holder for samples where more than the cutoff of probabilities are detected.
-    Returns
+
+    Returns:
         (array): Samples, with shape [num_sample, num_modes]
     """
     num_modes = len(probabilities.shape)

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -17,7 +17,7 @@
 import numpy as np
 import pytest
 from scipy.linalg import block_diag
-from thewalrus.quantum import density_matrix, state_vector, generate_probabilities, update_probabilities_with_loss
+from thewalrus.quantum import density_matrix, state_vector, probabilities, update_probabilities_with_loss
 from thewalrus.symplectic import expand, interferometer, two_mode_squeezing, loss
 
 
@@ -87,7 +87,7 @@ def test_four_modes(hbar):
         means, cov = loss(means, cov, eta, i, hbar=hbar)
 
     cutoff = 3
-    probs_lossless = generate_probabilities(means_lossless, cov_lossless, 4 * cutoff, hbar=hbar)
-    probs = generate_probabilities(means, cov, cutoff, hbar=hbar)
+    probs_lossless = probabilities(means_lossless, cov_lossless, 4 * cutoff, hbar=hbar)
+    probs = probabilities(means, cov, cutoff, hbar=hbar)
     probs_updated = update_probabilities_with_loss(etas, probs_lossless)
     assert np.allclose(probs, probs_updated[:cutoff, :cutoff, :cutoff, :cutoff], atol=1e-6)

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -51,6 +51,7 @@ def test_cubic_phase(hbar):
 
 @pytest.mark.parametrize("hbar", [2.0, 1.0/137])
 def test_four_modes(hbar):
+    """ Test that probabilities are correctly updates for a four modes system under loss"""
     # All this block is to generate the correct covariance matrix.
     # It correnponds to num_modes=4 modes that undergo two mode squeezing between modes i and i + (num_modes / 2)
     # The signal and idlers see and interferometer with unitary matrix u2x2
@@ -82,7 +83,7 @@ def test_four_modes(hbar):
         means, cov = loss(means, cov, eta, i, hbar=hbar)
 
     cutoff = 3
-    probs_lossless = generate_probabilities(means_lossless, cov_lossless, 4 * cutoff, hbar = hbar)
+    probs_lossless = generate_probabilities(means_lossless, cov_lossless, 4 * cutoff, hbar=hbar)
     probs = generate_probabilities(means, cov, cutoff, hbar=hbar)
     probs_updated = update_probabilities_with_loss(etas, probs_lossless)
-    assert np.allclose(probs, probs_updated[:cutoff, :cutoff, :cutoff, :cutoff], atol = 1e-6)
+    assert np.allclose(probs, probs_updated[:cutoff, :cutoff, :cutoff, :cutoff], atol=1e-6)

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -49,6 +49,7 @@ def test_cubic_phase(hbar):
     assert np.allclose(np.outer(psi_c, psi_c.conj()), rho)
     assert np.allclose(rho_c, rho)
 
+
 @pytest.mark.parametrize("hbar", [2.0, 1.0/137])
 def test_four_modes(hbar):
     """ Test that probabilities are correctly updates for a four modes system under loss"""

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -53,9 +53,10 @@ def test_cubic_phase(hbar):
 def test_four_modes(hbar):
     """ Test that probabilities are correctly updates for a four modes system under loss"""
     # All this block is to generate the correct covariance matrix.
-    # It correnponds to num_modes=4 modes that undergo two mode squeezing between modes i and i + (num_modes / 2)
-    # The signal and idlers see and interferometer with unitary matrix u2x2
-    # And then they see loss by amount eta
+    # It correnponds to num_modes=4 modes that undergo two mode squeezing between modes i and i + (num_modes / 2).
+    # Then they undergo displacement.
+    # The signal and idlers see and interferometer with unitary matrix u2x2.
+    # And then they see loss by amount etas[i].
     num_modes = 4
     theta = 0.45
     phi = 0.7

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -19,6 +19,8 @@ import pytest
 from scipy.linalg import block_diag
 from thewalrus.quantum import density_matrix, state_vector, generate_probabilities, update_probabilities_with_loss
 from thewalrus.symplectic import expand, interferometer, two_mode_squeezing, loss
+
+
 @pytest.mark.parametrize("hbar", [0.1, 0.5, 1, 2, 1.0/137])
 def test_cubic_phase(hbar):
     """Test that all the possible ways of obtaining a cubic phase state using the different methods agree"""

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -48,7 +48,7 @@ from thewalrus.quantum import (
     fock_tensor,
     photon_number_mean_vector,
     photon_number_mean,
-    generate_probabilities,
+    probabilities,
     update_probabilities_with_loss,
     loss_mat,
 )
@@ -948,8 +948,8 @@ def test_update_with_loss_two_mode_squeezed(etas, etai, hbar):
         mean2, cov2l = loss(mean2, cov2l, eta, i, hbar=hbar)
 
     cutoff = 6
-    probs = generate_probabilities(mean2, cov2l, cutoff, hbar=hbar)
-    probs_lossless = generate_probabilities(mean2, cov2, 3 * cutoff, hbar=hbar)
+    probs = probabilities(mean2, cov2l, cutoff, hbar=hbar)
+    probs_lossless = probabilities(mean2, cov2, 3 * cutoff, hbar=hbar)
     probs_updated = update_probabilities_with_loss(eta2, probs_lossless)
 
     assert np.allclose(probs, probs_updated[:cutoff, :cutoff], atol=1.0e-5)
@@ -966,9 +966,9 @@ def test_update_with_loss_coherent_states(etas, etai, hbar):
     means = 2 * np.random.rand(2 * n_modes)
     means_lossy = np.sqrt(np.array(eta_vals + eta_vals)) * means
     cutoff = 6
-    probs_lossless = generate_probabilities(means, cov, 10 * cutoff, hbar=hbar)
+    probs_lossless = probabilities(means, cov, 10 * cutoff, hbar=hbar)
 
-    probs = generate_probabilities(means_lossy, cov, cutoff, hbar=hbar)
+    probs = probabilities(means_lossy, cov, cutoff, hbar=hbar)
     probs_updated = update_probabilities_with_loss(eta_vals, probs_lossless)
 
     assert np.allclose(probs, probs_updated[:cutoff, :cutoff], atol=1.0e-5)

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -960,6 +960,7 @@ def test_update_with_loss_two_mode_squeezed(etas, etai, hbar):
 @pytest.mark.parametrize("etas", [0.1, 0.4, 0.9, 1.0])
 @pytest.mark.parametrize("etai", [0.1, 0.4, 0.9, 1.0])
 def test_update_with_loss_coherent_states(etas, etai, hbar):
+    """Checks probabilities are updated correctly for coherent states"""
     n_modes = 2
     cov = hbar * np.identity(2 * n_modes) / 2
     eta_vals = [etas, etai]

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -50,6 +50,7 @@ from thewalrus.quantum import (
     photon_number_mean,
     generate_probabilities,
     update_probabilities_with_loss,
+    loss_mat,
 )
 
 
@@ -971,3 +972,30 @@ def test_update_with_loss_coherent_states(etas, etai, hbar):
     probs_updated = update_probabilities_with_loss(eta_vals, probs_lossless)
 
     assert np.allclose(probs, probs_updated[:cutoff, :cutoff], atol=1.0e-5)
+
+
+
+@pytest.mark.parametrize("eta", [0.1, 0.5, 1.0])
+def test_loss_is_stochastic_matrix(eta):
+    """Test the loss matrix is an stochastic matrix, implying that the sum
+    of the entries a long the rows is 1"""
+    n = 50
+    M = loss_mat(eta, n)
+    assert np.allclose(np.sum(M, axis=1), np.ones([n]))
+
+
+@pytest.mark.parametrize("eta", [0.1, 0.5, 1.0])
+def test_loss_is_nonnegative_matrix(eta):
+    """Test the loss matrix is a nonnegative matrix"""
+    n = 50
+    M = loss_mat(eta, n)
+    assert np.alltrue(M >= 0.0)
+
+@pytest.mark.parametrize("eta", [-1.0, 2.0])
+def test_loss_value_error(eta):
+    """Tests the correct error is raised"""
+    n = 50
+    with pytest.raises(
+        ValueError, match="The transmission parameter eta should be a number between 0 and 1."
+    ):
+        loss_mat(eta, n)

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -974,7 +974,6 @@ def test_update_with_loss_coherent_states(etas, etai, hbar):
     assert np.allclose(probs, probs_updated[:cutoff, :cutoff], atol=1.0e-5)
 
 
-
 @pytest.mark.parametrize("eta", [0.1, 0.5, 1.0])
 def test_loss_is_stochastic_matrix(eta):
     """Test the loss matrix is an stochastic matrix, implying that the sum

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -938,7 +938,6 @@ def test_pnd_squeeze_displace(tol, r, phi, alpha, hbar):
 @pytest.mark.parametrize("etai", [0.1, 0.4, 0.9, 1.0])
 def test_update_with_loss_two_mode_squeezed(etas, etai, hbar):
     """Test the probabilities are updated correctly for a lossy two mode squeezed vacuum state"""
-#    hbar = 2.0
     cov2 = two_mode_squeezing(np.arcsinh(1.0), 0.0)
     cov2 = hbar * cov2 @ cov2.T / 2.0
     mean2 = np.zeros([4])

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -990,6 +990,7 @@ def test_loss_is_nonnegative_matrix(eta):
     M = loss_mat(eta, n)
     assert np.alltrue(M >= 0.0)
 
+
 @pytest.mark.parametrize("eta", [-1.0, 2.0])
 def test_loss_value_error(eta):
     """Tests the correct error is raised"""

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -26,9 +26,9 @@ from thewalrus.samples import (
     hafnian_sample_classical_state,
     torontonian_sample_classical_state,
     seed,
+    photon_number_sampler,
 )
-from thewalrus.quantum import gen_Qmat_from_graph, density_matrix_element
-
+from thewalrus.quantum import gen_Qmat_from_graph, density_matrix_element, generate_probabilities
 seed(137)
 
 rel_tol = 3.0
@@ -442,9 +442,6 @@ class TestTorontonianSampling:
         samples = torontonian_sample_graph(A, mean_n, samples=n_samples, parallel=parallel)
         assert np.all(samples[:, 0] == samples[:, 1])
 
-from thewalrus.quantum import generate_probabilities
-from thewalrus.samples import photon_number_sampler
-
 def test_photon_number_sampler_two_mode_squeezed():
     """Test the brute force sampler when one truncates the probability distribution """
     hbar = 2.0
@@ -452,7 +449,7 @@ def test_photon_number_sampler_two_mode_squeezed():
     cov = TMS_cov(r, 0.0)
     cutoff = 10
     probs = generate_probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
-    samples = np.array(photon_number_sampler(probs, 1000, renorm=True))
+    samples = np.array(photon_number_sampler(probs, 1000))
     assert np.allclose(samples[:, 0], samples[:, 1])
 
 def test_photon_number_sampler_out_of_bounds():
@@ -462,7 +459,7 @@ def test_photon_number_sampler_out_of_bounds():
     cov = TMS_cov(r, 0.0)
     cutoff = 5
     probs = generate_probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
-    samples = photon_number_sampler(probs, 1000, renorm=False, out_of_bounds = 'Coo coo ca choo')
+    samples = photon_number_sampler(probs, 1000, out_of_bounds='Coo coo ca choo')
     assert 'Coo coo ca choo' in samples
     numerical_samples = np.array([x for x in samples if x!='Coo coo ca choo'])
     assert np.allclose(numerical_samples[:, 0], numerical_samples[:, 1])

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -442,6 +442,7 @@ class TestTorontonianSampling:
         samples = torontonian_sample_graph(A, mean_n, samples=n_samples, parallel=parallel)
         assert np.all(samples[:, 0] == samples[:, 1])
 
+
 def test_photon_number_sampler_two_mode_squeezed():
     """Test the brute force sampler when one truncates the probability distribution """
     hbar = 2.0

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -28,7 +28,7 @@ from thewalrus.samples import (
     seed,
     photon_number_sampler,
 )
-from thewalrus.quantum import gen_Qmat_from_graph, density_matrix_element, generate_probabilities
+from thewalrus.quantum import gen_Qmat_from_graph, density_matrix_element, probabilities
 seed(137)
 
 rel_tol = 3.0
@@ -449,7 +449,7 @@ def test_photon_number_sampler_two_mode_squeezed():
     r = np.arcsinh(1.0)
     cov = TMS_cov(r, 0.0)
     cutoff = 10
-    probs = generate_probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
+    probs = probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
     samples = np.array(photon_number_sampler(probs, 1000))
     assert np.allclose(samples[:, 0], samples[:, 1])
 
@@ -460,7 +460,7 @@ def test_photon_number_sampler_out_of_bounds():
     r = np.arcsinh(np.sqrt(100))
     cov = TMS_cov(r, 0.0)
     cutoff = 5
-    probs = generate_probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
+    probs = probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
     samples = photon_number_sampler(probs, 1000, out_of_bounds='Coo coo ca choo')
     assert 'Coo coo ca choo' in samples
     numerical_samples = np.array([x for x in samples if x != "Coo coo ca choo"])

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -461,7 +461,7 @@ def test_photon_number_sampler_out_of_bounds():
     probs = generate_probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
     samples = photon_number_sampler(probs, 1000, out_of_bounds='Coo coo ca choo')
     assert 'Coo coo ca choo' in samples
-    numerical_samples = np.array([x for x in samples if x!='Coo coo ca choo'])
+    numerical_samples = np.array([x for x in samples if x != "Coo coo ca choo"])
     assert np.allclose(numerical_samples[:, 0], numerical_samples[:, 1])
 
 def test_seed():

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -453,6 +453,7 @@ def test_photon_number_sampler_two_mode_squeezed():
     samples = np.array(photon_number_sampler(probs, 1000))
     assert np.allclose(samples[:, 0], samples[:, 1])
 
+
 def test_photon_number_sampler_out_of_bounds():
     """Test the brute force sampler when one use 'Coo coo ca choo' as the string for out_of_bounds"""
     hbar = 2.0
@@ -464,6 +465,7 @@ def test_photon_number_sampler_out_of_bounds():
     assert 'Coo coo ca choo' in samples
     numerical_samples = np.array([x for x in samples if x != "Coo coo ca choo"])
     assert np.allclose(numerical_samples[:, 0], numerical_samples[:, 1])
+
 
 def test_seed():
     """Tests that seed method does reset the random number generators"""

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -442,6 +442,30 @@ class TestTorontonianSampling:
         samples = torontonian_sample_graph(A, mean_n, samples=n_samples, parallel=parallel)
         assert np.all(samples[:, 0] == samples[:, 1])
 
+from thewalrus.quantum import generate_probabilities
+from thewalrus.samples import photon_number_sampler
+
+def test_photon_number_sampler_two_mode_squeezed():
+    """Test the brute force sampler when one truncates the probability distribution """
+    hbar = 2.0
+    r = np.arcsinh(1.0)
+    cov = TMS_cov(r, 0.0)
+    cutoff = 10
+    probs = generate_probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
+    samples = np.array(photon_number_sampler(probs, 1000, renorm=True))
+    assert np.allclose(samples[:, 0], samples[:, 1])
+
+def test_photon_number_sampler_out_of_bounds():
+    """Test the brute force sampler when one use 'Coo coo ca choo' as the string for out_of_bounds"""
+    hbar = 2.0
+    r = np.arcsinh(np.sqrt(100))
+    cov = TMS_cov(r, 0.0)
+    cutoff = 5
+    probs = generate_probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
+    samples = photon_number_sampler(probs, 1000, renorm=False, out_of_bounds = 'Coo coo ca choo')
+    assert 'Coo coo ca choo' in samples
+    numerical_samples = np.array([x for x in samples if x!='Coo coo ca choo'])
+    assert np.allclose(numerical_samples[:, 0], numerical_samples[:, 1])
 
 def test_seed():
     """Tests that seed method does reset the random number generators"""


### PR DESCRIPTION
Adds a number of methods for calculating the photon number distributions.

* Adds the ability to calculate the photon number distribution of a pure state or mixed state using `generate_probabilities`. 

* Allows to update the photon number distirbution when undergoing loss by using `update_probabilities_with_loss`. 

* Adds a brute force sampler `photon_number_sampler` that given a (multi-)mode photon number distribution generates photon number samples.