### PR TITLE
Remove py35 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     docker:
       - image: circleci/python:3.6.8-stretch
     environment:
-      CIBW_SKIP: "cp27-* cp34-* *i686"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
       CIBW_BEFORE_BUILD_LINUX: curl -OsL https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz && tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
       CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus
@@ -107,7 +107,7 @@ jobs:
     macos:
       xcode: "10.0.0"
     environment:
-      CIBW_SKIP: "cp27-* cp34-* *i686"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
       CIBW_BEFORE_BUILD_MACOS: brew cask uninstall --force oclint && brew install gcc eigen libomp || true; brew install gcc eigen libomp && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
       CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Improvements
 
+* Removes support for Python 3.5. [#163](https://github.com/XanaduAI/thewalrus/pull/163)
+
 ### Bug fixes
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Theodor Isacsson
 
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,6 @@ Pre-built binary wheels are available for the following platforms:
 +------------+-------------+------------------+---------------+
 |            | macOS 10.6+ | manylinux x86_64 | Windows 64bit |
 +============+=============+==================+===============+
-| Python 3.5 |      X      |        X         |       X       |
-+------------+-------------+------------------+---------------+
 | Python 3.6 |      X      |        X         |       X       |
 +------------+-------------+------------------+---------------+
 | Python 3.7 |      X      |        X         |       X       |
@@ -74,9 +72,9 @@ Compiling from source
 
 The Walrus depends on the following Python packages:
 
-* `Python <http://python.org/>`_ >=3.5
-* `NumPy <http://numpy.org/>`_  >=1.13.3
-* `Numba <https://numba.pydata.org/>`_ >=0.43.1
+* `Python <http://python.org/>`_ >= 3.6
+* `NumPy <http://numpy.org/>`_  >= 1.13.3
+* `Numba <https://numba.pydata.org/>`_ >= 0.43.1
 
 In addition, to compile the C++ extension, the following dependencies are required:
 
@@ -183,11 +181,11 @@ The Walrus documentation is available online on `Read the Docs <https://the-walr
 
 To build it locally, you need to have the following packages installed:
 
-* `Sphinx <http://sphinx-doc.org/>`_ >=1.5
-* `sphinxcontrib-bibtex <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/>`_ >=0.3.6
+* `Sphinx <http://sphinx-doc.org/>`_ >= 1.5
+* `sphinxcontrib-bibtex <https://sphinxcontrib-bibtex.readthedocs.io/en/latest/>`_ >= 0.3.6
 * `nbsphinx <https://github.com/spatialaudio/nbsphinx>`_
 * `Pandoc <https://pandoc.org/>`_
-* `breathe <https://breathe.readthedocs.io/en/latest/>`_ >=4.12.0
+* `breathe <https://breathe.readthedocs.io/en/latest/>`_ >= 4.12.0
 * `exhale <https://exhale.readthedocs.io/en/latest/>`_
 * `Doxygen <http://www.doxygen.nl/>`_
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
       EIGEN_INCLUDE_DIR: C:\eigen-eigen-323c052e1731\
       TEST_TIMEOUT: 1000
       CIBW_BEFORE_BUILD: pip install numpy scipy cython
-      CIBW_SKIP: "cp27-* cp33-* cp34-* *win32"
+      CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* *win32"
       CIBW_TEST_REQUIRES: "numpy scipy pytest pytest-cov"
       CIBW_TEST_COMMAND: "python -m pytest {project}/thewalrus"
       CIBW_BUILD_VERBOSITY: 3

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
**Context:**
`llvmlite` no longer provide wheels for Python 3.5 causing CI tests to fail. This is easiest solved by removing support for Python 3.5 in The Walrus (which is something that is already planned).

**Description of the Change:**
Support for Python 3.5 is removed from The Walrus by removing it from the CI suits, documentation and setup files.

**Benefits:**
CI tests will work again, and Python 3.5 support will be deprecated. Also, f-strings can be used.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#161 and #162 can now be merged.
