### PR TITLE
Evaluation of normal ordered expectation values

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Adds a new module, `thewalrus.random`, to generate random unitary, symplectic and covariance matrices. [#169](https://github.com/XanaduAI/thewalrus/pull/169)
 
-* Adds new function `normal_ordered_expectation` to calculate expectation value of product of normal ordered expressions. [#175](https://github.com/XanaduAI/thewalrus/pull/175)
+* Adds new function `normal_ordered_expectation` in `thewalrus.quantum` to calculate expectation values of products of normal ordered expressions. [#175](https://github.com/XanaduAI/thewalrus/pull/175)
 
 ### Improvements
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Adds a new module, `thewalrus.random`, to generate random unitary, symplectic and covariance matrices. [#169](https://github.com/XanaduAI/thewalrus/pull/169)
 
+* Adds new function `normal_ordered_expectation` to calculate expectation value of product of normal ordered expressions. [#175](https://github.com/XanaduAI/thewalrus/pull/175)
+
 ### Improvements
 
 * Removes support for Python 3.5. [#163](https://github.com/XanaduAI/thewalrus/pull/163)

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1325,7 +1325,6 @@ def normal_ordered_expectation(mu, cov, rpt, hbar=2):
     Returns:
         (float): expectation value of the normal ordered product of operators
     """
-    V = gen_normal_ordered_complex_cov(cov, hbar=hbar)
     alpha = Beta(mu, hbar=hbar)
     V = gen_normal_ordered_complex_cov(cov, hbar=hbar)
     A = reduction(V, rpt)

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1323,8 +1323,6 @@ def normal_ordered_expectation(mu, cov, rpt, hbar=2):
     Returns:
         (float): expectation value of the normal ordered product of operators
     """
-    n, _ = cov.shape
-    n_modes = n // 2
     V = gen_normal_ordered_complex_cov(cov, hbar=hbar)
     alpha = Beta(mu, hbar=hbar)
     V = gen_normal_ordered_complex_cov(cov, hbar=hbar)

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1298,8 +1298,8 @@ def gen_normal_ordered_complex_cov(cov, hbar=2):
     """
 
     n, _ = cov.shape
-    n_modes = n//2
-    cov = cov/(hbar/2)
+    n_modes = n // 2
+    cov = cov / (hbar / 2)
     A = cov[:n_modes, :n_modes]
     B = cov[:n_modes, n_modes:]
     C = cov[n_modes:, n_modes:]
@@ -1307,6 +1307,7 @@ def gen_normal_ordered_complex_cov(cov, hbar=2):
     M = 0.25 * (A - C + 1j * (B + B.T))
     mat = np.block([[M.conj(), N], [N.T, M]])
     return mat
+
 
 def normal_ordered_expectation(mu, cov, rpt, hbar=2):
     r"""Calculates the expectation value of the normal ordered product
@@ -1323,7 +1324,7 @@ def normal_ordered_expectation(mu, cov, rpt, hbar=2):
         (float): expectation value of the normal ordered product of operators
     """
     n, _ = cov.shape
-    n_modes = n//2
+    n_modes = n // 2
     V = gen_normal_ordered_complex_cov(cov, hbar=hbar)
     alpha = Beta(mu, hbar=hbar)
     rpt1 = rpt[:n_modes]

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -117,7 +117,7 @@ Utility functions
     total_photon_num_dist_pure_state
     gen_single_mode_dist
     gen_multi_mode_dist
-    gen_normal_ordered_complex_cov
+    normal_ordered_complex_cov
 
 
 Details
@@ -1360,7 +1360,7 @@ def normal_ordered_expectation(mu, cov, rpt, hbar=2):
         (float): expectation value of the normal ordered product of operators
     """
     alpha = Beta(mu, hbar=hbar)
-    V = gen_normal_ordered_complex_cov(cov, hbar=hbar)
+    V = normal_ordered_complex_cov(cov, hbar=hbar)
     A = reduction(V, rpt)
     if np.allclose(mu, 0):
         res = np.conj(hafnian(A))

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1327,13 +1327,11 @@ def normal_ordered_expectation(mu, cov, rpt, hbar=2):
     n_modes = n // 2
     V = gen_normal_ordered_complex_cov(cov, hbar=hbar)
     alpha = Beta(mu, hbar=hbar)
-    rpt1 = rpt[:n_modes]
-    rpt2 = rpt[n_modes:]
     V = gen_normal_ordered_complex_cov(cov, hbar=hbar)
-    Amat = reduction(V, rpt)
+    A = reduction(V, rpt)
     if np.allclose(mu, 0):
-        res = np.conj(hafnian(Amat))
+        res = np.conj(hafnian(A))
     else:
-        np.fill_diagonal(Amat, reduction(np.conj(alpha), rpt))
-        res = np.conj(hafnian(Amat, loop=True))
+        np.fill_diagonal(A, reduction(np.conj(alpha), rpt))
+        res = np.conj(hafnian(A, loop=True))
     return np.conj(res)

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1333,6 +1333,6 @@ def normal_ordered_expectation(mu, cov, rpt, hbar=2):
     if np.allclose(mu, 0):
         res = np.conj(hafnian(Amat))
     else:
-        np.fill_diagonal(Amat, reduction(alpha, rpt))
-        res = hafnian(Amat,loop=True)
+        np.fill_diagonal(Amat, reduction(np.conj(alpha), rpt))
+        res = np.conj(hafnian(Amat, loop=True))
     return np.conj(res)

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1335,3 +1335,48 @@ def normal_ordered_expectation(mu, cov, rpt, hbar=2):
         np.fill_diagonal(A, reduction(np.conj(alpha), rpt))
         res = np.conj(hafnian(A, loop=True))
     return np.conj(res)
+
+def photon_number_expectation(mu, cov, modes, hbar=2):
+    r"""Calculates the expectation value of the product of the number operator of the modes in a Gaussian state.
+
+    Args:
+        mu (array): length-:math:`2N` means vector in xp-ordering.
+        cov (array): :math:`2N\times 2N` covariance matrix in xp-ordering.
+        modes (list): list of modes
+        hbar (float): value of hbar in the uncertainty relation.
+
+    Returns:
+        (float): expectation value of the product of the number operators of the modes.
+    """
+    n, _ = cov.shape
+    n_modes = n // 2
+    rpt = np.zeros([n], dtype=int)
+    for i in modes:
+        rpt[i] = 1
+        rpt[i + n_modes] = 1
+
+    return normal_ordered_expectation(mu, cov, rpt, hbar=hbar)
+
+
+def photon_number_squared_expectation(mu, cov, modes, hbar=2):
+    r"""Calculates the expectation value of the square of the product of the number operator of the modes in
+    a Gaussian state.
+
+    Args:
+        mu (array): length-:math:`2N` means vector in xp-ordering.
+        cov (array): :math:`2N\times 2N` covariance matrix in xp-ordering.
+        modes (list): list of modes
+        hbar (float): value of hbar in the uncertainty relation.
+
+    Returns:
+        (float): expectation value of the square of the product of the number operator of the modes.
+    """
+    n_modes = len(modes)
+
+    mu_red, cov_red = reduced_gaussian(mu, cov, modes)
+    result = 0
+    for item in product([1, 2], repeat=n_modes):
+        rpt = item + item
+        term = normal_ordered_expectation(mu_red, cov_red, rpt, hbar=hbar)
+        result += term
+    return result

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -1322,7 +1322,7 @@ def fidelity(mu1, cov1, mu2, cov2, hbar=2, rtol=1e-05, atol=1e-08):
     )
     return f
 
-def gen_normal_ordered_complex_cov(cov, hbar=2):
+def normal_ordered_complex_cov(cov, hbar=2):
     r"""Calculates the normal ordered covariance matrix in the complex basis.
 
     Args:

--- a/thewalrus/quantum.py
+++ b/thewalrus/quantum.py
@@ -53,6 +53,7 @@ Fock states and tensors
     probabilities
     update_probabilities_with_loss
     update_probabilities_with_noise
+    normal_ordered_expectation
     fidelity
 
 Details
@@ -109,6 +110,7 @@ Utility functions
     total_photon_num_dist_pure_state
     gen_single_mode_dist
     gen_multi_mode_dist
+    gen_normal_ordered_complex_cov
 
 
 Details

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -1144,6 +1144,7 @@ def test_single_mode_squeezed(r, phi, hbar):
 @pytest.mark.parametrize("x", np.random.rand(4)-0.5)
 @pytest.mark.parametrize("y", np.random.rand(4)-0.5)
 def test_single_mode_displaced_squeezed(r, phi, x, y):
+    """Tests the correct results are obtained for a single mode displaced squeezed state"""
     hbar = 2
     S = squeezing(r, phi)
     cov = 0.5*hbar*S@S.T
@@ -1157,10 +1158,24 @@ def test_single_mode_displaced_squeezed(r, phi, x, y):
     expected = [1, adxa, a, np.conj(a), a2, np.conj(a2)]
 
 
-    for pattern, value in zip(patterns[-2:], expected[-2:]):
+    for pattern, value in zip(patterns, expected):
         result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
-        #print(phi,result, np.round(value,10))
         assert np.allclose(result, value)
-    #result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
-    #print(result, )
+
+@pytest.mark.parametrize("r", np.random.rand(4))
+@pytest.mark.parametrize("phi", 2*np.pi*np.random.rand(4))
+def two_mode_squeezed(r, phi):
+    hbar = 2
+    S = two_mode_squeezing(r, phi)
+    cov = 0.5*hbar*S@S.T
+    means = np.zeros([4])
+    a = 0
+    a2 = 0.5*np.exp(1j*phi)*np.sinh(2*r)
+    adxa = np.sinh(r)**2
+
+    patterns = [[0,0], [0,1], [1,0], [1,1], [0,2], [2,0]]
+    expected = [1, 0, 0,, adxa, a2, np.conj(a2)]
+
+
+
 

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -1104,78 +1104,117 @@ def test_fidelity_wrong_shape():
     ):
         fidelity(mu, cov1, mu, cov2)
 
+
 @pytest.mark.parametrize("hbar", [0.5, 1, 2, 1.6])
-@pytest.mark.parametrize("alpha", np.random.rand(3,10) + 1j*np.random.rand(3,10))
+@pytest.mark.parametrize("alpha", np.random.rand(3, 10) + 1j * np.random.rand(3, 10))
 def test_expectation_normal_ordered_coherent(alpha, hbar):
     """Test the correct evaluation of the normal ordered expectation value for a product of coherent states"""
     beta = np.concatenate([alpha, np.conj(alpha)])
     means = Means(beta, hbar=hbar)
-    cov = np.identity(len(beta))*hbar/2
-    pattern = np.random.randint(low = 0, high = 3, size = len(beta))
+    cov = np.identity(len(beta)) * hbar / 2
+    pattern = np.random.randint(low=0, high=3, size=len(beta))
     result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
-    np.allclose(result, np.prod(np.conj(beta)**pattern))
+    np.allclose(result, np.prod(np.conj(beta) ** pattern))
+
 
 @pytest.mark.parametrize("hbar", [0.5, 1, 2, 1.6])
 @pytest.mark.parametrize("r", np.random.rand(5))
-@pytest.mark.parametrize("phi", 2*np.pi*np.random.rand(5))
+@pytest.mark.parametrize("phi", 2 * np.pi * np.random.rand(5))
 def test_single_mode_squeezed(r, phi, hbar):
     """Tests the correct results are obtained for a single mode squeezed state"""
     S = squeezing(r, phi)
-    cov = 0.5*hbar*S@S.T
+    cov = 0.5 * hbar * S @ S.T
     means = np.zeros([2])
 
-    patterns = [[0,0], [1,1], [0,1], [1,0],[0,2],[2,0],[0,4],[4,0],[2,2],[3,1],[1,3]]
+    patterns = [
+        [0, 0],
+        [1, 1],
+        [0, 1],
+        [1, 0],
+        [0, 2],
+        [2, 0],
+        [0, 4],
+        [4, 0],
+        [2, 2],
+        [3, 1],
+        [1, 3],
+    ]
 
-    adxa = np.sinh(r)**2
+    adxa = np.sinh(r) ** 2
     a = 0
-    a2 = -0.5*np.exp(1j*phi)*np.sinh(2*r)
-    a4 = 3*np.exp(2j*phi)*(0.5*np.sinh(2*r))**2
-    ad2xa2 = (np.cosh(r)**2+2*np.sinh(r)**2)*np.sinh(r)**2
-    ad3xa = -3*np.exp(-1j*phi)*np.cosh(r)*np.sinh(r)**3
+    a2 = -0.5 * np.exp(1j * phi) * np.sinh(2 * r)
+    a4 = 3 * np.exp(2j * phi) * (0.5 * np.sinh(2 * r)) ** 2
+    ad2xa2 = (np.cosh(r) ** 2 + 2 * np.sinh(r) ** 2) * np.sinh(r) ** 2
+    ad3xa = -3 * np.exp(-1j * phi) * np.cosh(r) * np.sinh(r) ** 3
 
-    expected = [1, adxa, a, np.conj(a), a2, np.conj(a2), a4, np.conj(a4), ad2xa2, ad3xa, np.conj(ad3xa)]
+    expected = [
+        1,
+        adxa,
+        a,
+        np.conj(a),
+        a2,
+        np.conj(a2),
+        a4,
+        np.conj(a4),
+        ad2xa2,
+        ad3xa,
+        np.conj(ad3xa),
+    ]
 
     for pattern, value in zip(patterns, expected):
         result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
         assert np.allclose(result, value)
 
+
 @pytest.mark.parametrize("r", np.random.rand(4))
-@pytest.mark.parametrize("phi", 2*np.pi*np.random.rand(4))
-@pytest.mark.parametrize("x", np.random.rand(4)-0.5)
-@pytest.mark.parametrize("y", np.random.rand(4)-0.5)
+@pytest.mark.parametrize("phi", 2 * np.pi * np.random.rand(4))
+@pytest.mark.parametrize("x", np.random.rand(4) - 0.5)
+@pytest.mark.parametrize("y", np.random.rand(4) - 0.5)
 def test_single_mode_displaced_squeezed(r, phi, x, y):
     """Tests the correct results are obtained for a single mode displaced squeezed state"""
     hbar = 2
     S = squeezing(r, phi)
-    cov = 0.5*hbar*S@S.T
-    beta = np.array([x+1j*y, x-1j*y])
+    cov = 0.5 * hbar * S @ S.T
+    beta = np.array([x + 1j * y, x - 1j * y])
     alpha = beta[0]
     means = Means(beta, hbar=hbar)
     a = alpha
-    adxa = np.abs(alpha)**2+np.sinh(r)**2
-    a2 =alpha**2 -  np.exp(1j*phi)*0.5*np.sinh(2*r)
-    patterns = [[0,0], [1,1], [0,1], [1,0], [0,2], [2,0]]
+    adxa = np.abs(alpha) ** 2 + np.sinh(r) ** 2
+    a2 = alpha ** 2 - np.exp(1j * phi) * 0.5 * np.sinh(2 * r)
+    patterns = [[0, 0], [1, 1], [0, 1], [1, 0], [0, 2], [2, 0]]
     expected = [1, adxa, a, np.conj(a), a2, np.conj(a2)]
-
 
     for pattern, value in zip(patterns, expected):
         result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
         assert np.allclose(result, value)
 
+
 @pytest.mark.parametrize("r", np.random.rand(4))
-@pytest.mark.parametrize("phi", 2*np.pi*np.random.rand(4))
-def two_mode_squeezed(r, phi):
+@pytest.mark.parametrize("phi", 2 * np.pi * np.random.rand(4))
+def test_expt_two_mode_squeezed(r, phi):
+    """tests for two mode squeezing"""
     hbar = 2
     S = two_mode_squeezing(r, phi)
-    cov = 0.5*hbar*S@S.T
+    cov = 0.5 * hbar * S @ S.T
     means = np.zeros([4])
     a = 0
-    a2 = 0.5*np.exp(1j*phi)*np.sinh(2*r)
-    adxa = np.sinh(r)**2
-
-    patterns = [[0,0], [0,1], [1,0], [1,1], [0,2], [2,0]]
-    expected = [1, 0, 0,, adxa, a2, np.conj(a2)]
-
-
-
-
+    a2 = 0.5 * np.exp(1j * phi) * np.sinh(2 * r)
+    adxa = np.sinh(r) ** 2
+    adxbdxab = np.cosh(2 * r) * np.sinh(r) ** 2
+    ad2bd2 = 0.5 * np.exp(-2j * phi) * (np.sinh(2 * r)) ** 2
+    patterns = [
+        [0, 0, 0, 0],
+        [0, 0, 0, 1],
+        [1, 0, 0, 0],
+        [1, 0, 1, 0],
+        [0, 1, 0, 1],
+        [0, 0, 1, 1],
+        [1, 1, 0, 0],
+        [1, 1, 1, 1],
+        [2, 2, 0, 0],
+        [0, 0, 2, 2],
+    ]
+    expected = [1, 0, 0, adxa, adxa, a2, np.conj(a2), adxbdxab, ad2bd2, np.conj(ad2bd2)]
+    for pattern, value in zip(patterns, expected):
+        result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
+        assert np.allclose(result, value)

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -1194,7 +1194,8 @@ def test_single_mode_displaced_squeezed(r, phi, x, y):
 @pytest.mark.parametrize("r", np.random.rand(4))
 @pytest.mark.parametrize("phi", 2 * np.pi * np.random.rand(4))
 def test_expt_two_mode_squeezed(r, phi):
-    """tests for two mode squeezing"""
+    """Tests that the correct results are obtained for a state created by two-mode squeezing"""
+
     hbar = 2
     S = two_mode_squeezing(r, phi)
     cov = 0.5 * hbar * S @ S.T

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -55,6 +55,7 @@ from thewalrus.quantum import (
     update_probabilities_with_noise,
     loss_mat,
     fidelity,
+    normal_ordered_expectation,
 )
 
 
@@ -1102,3 +1103,64 @@ def test_fidelity_wrong_shape():
         ValueError, match="The inputs have incompatible shapes"
     ):
         fidelity(mu, cov1, mu, cov2)
+
+@pytest.mark.parametrize("hbar", [0.5, 1, 2, 1.6])
+@pytest.mark.parametrize("alpha", np.random.rand(3,10) + 1j*np.random.rand(3,10))
+def test_expectation_normal_ordered_coherent(alpha, hbar):
+    """Test the correct evaluation of the normal ordered expectation value for a product of coherent states"""
+    beta = np.concatenate([alpha, np.conj(alpha)])
+    means = Means(beta, hbar=hbar)
+    cov = np.identity(len(beta))*hbar/2
+    pattern = np.random.randint(low = 0, high = 3, size = len(beta))
+    result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
+    np.allclose(result, np.prod(np.conj(beta)**pattern))
+
+@pytest.mark.parametrize("hbar", [0.5, 1, 2, 1.6])
+@pytest.mark.parametrize("r", np.random.rand(5))
+@pytest.mark.parametrize("phi", 2*np.pi*np.random.rand(5))
+def test_single_mode_squeezed(r, phi, hbar):
+    """Tests the correct results are obtained for a single mode squeezed state"""
+    S = squeezing(r, phi)
+    cov = 0.5*hbar*S@S.T
+    means = np.zeros([2])
+
+    patterns = [[0,0], [1,1], [0,1], [1,0],[0,2],[2,0],[0,4],[4,0],[2,2],[3,1],[1,3]]
+
+    adxa = np.sinh(r)**2
+    a = 0
+    a2 = -0.5*np.exp(1j*phi)*np.sinh(2*r)
+    a4 = 3*np.exp(2j*phi)*(0.5*np.sinh(2*r))**2
+    ad2xa2 = (np.cosh(r)**2+2*np.sinh(r)**2)*np.sinh(r)**2
+    ad3xa = -3*np.exp(-1j*phi)*np.cosh(r)*np.sinh(r)**3
+
+    expected = [1, adxa, a, np.conj(a), a2, np.conj(a2), a4, np.conj(a4), ad2xa2, ad3xa, np.conj(ad3xa)]
+
+    for pattern, value in zip(patterns, expected):
+        result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
+        assert np.allclose(result, value)
+
+@pytest.mark.parametrize("r", np.random.rand(4))
+@pytest.mark.parametrize("phi", 2*np.pi*np.random.rand(4))
+@pytest.mark.parametrize("x", np.random.rand(4)-0.5)
+@pytest.mark.parametrize("y", np.random.rand(4)-0.5)
+def test_single_mode_displaced_squeezed(r, phi, x, y):
+    hbar = 2
+    S = squeezing(r, phi)
+    cov = 0.5*hbar*S@S.T
+    beta = np.array([x+1j*y, x-1j*y])
+    alpha = beta[0]
+    means = Means(beta, hbar=hbar)
+    a = alpha
+    adxa = np.abs(alpha)**2+np.sinh(r)**2
+    a2 =alpha**2 -  np.exp(1j*phi)*0.5*np.sinh(2*r)
+    patterns = [[0,0], [1,1], [0,1], [1,0], [0,2], [2,0]]
+    expected = [1, adxa, a, np.conj(a), a2, np.conj(a2)]
+
+
+    for pattern, value in zip(patterns[-2:], expected[-2:]):
+        result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
+        #print(phi,result, np.round(value,10))
+        assert np.allclose(result, value)
+    #result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
+    #print(result, )
+

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -1245,7 +1245,8 @@ def test_photon_number_expectation_displaced(alpha, hbar):
 @pytest.mark.parametrize("r", np.random.rand(5))
 @pytest.mark.parametrize("phi", 2 * np.pi * np.random.rand(5))
 def test_photon_number_expectation_squeezed(r, phi, hbar):
-    """Tests tthe correct photon number expectation of a single mode squeezed state"""
+    """Tests the correct photon number expectation of a single mode squeezed state"""
+
     S = squeezing(r, phi)
     cov = 0.5 * hbar * S @ S.T
     means = np.zeros([2])
@@ -1261,7 +1262,8 @@ def test_photon_number_expectation_squeezed(r, phi, hbar):
 @pytest.mark.parametrize("r", np.random.rand(5))
 @pytest.mark.parametrize("phi", 2 * np.pi * np.random.rand(5))
 def test_photon_number_expectation_two_mode_squeezed(r, phi, hbar):
-    """Tests tthe correct photon number expectation of a two-mode squeezed state"""
+    """Tests the correct photon number expectation of a two-mode squeezed state"""
+
     S = two_mode_squeezing(r, phi)
     cov = 0.5 * hbar * S @ S.T
     means = np.zeros([4])

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -1214,7 +1214,7 @@ def test_expt_two_mode_squeezed(r, phi):
         [2, 2, 0, 0],
         [0, 0, 2, 2],
     ]
-    expected = [1, 0, 0, adxa, adxa, a2, np.conj(a2), adxbdxab, ad2bd2, np.conj(ad2bd2)]
+    expected = [1, a, np.conj(a), adxa, adxa, a2, np.conj(a2), adxbdxab, ad2bd2, np.conj(ad2bd2)]
     for pattern, value in zip(patterns, expected):
         result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
         assert np.allclose(result, value)


### PR DESCRIPTION
Allows to calculate the expectation value of arbitrary products of normal ordered expression in creation and annihilation operators of the form 

![image](https://user-images.githubusercontent.com/991946/82718755-787ec480-9c72-11ea-8fca-89118db1a09d.png)

where the value of the indices are passed as

![image](https://user-images.githubusercontent.com/991946/82718781-a401af00-9c72-11ea-9080-88471a5fbfad.png)
