### PR TITLE
Force MacOS wheels to support 10.9+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,7 @@ jobs:
       xcode: "10.0.0"
     environment:
       CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
+      CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=10.9"
       CIBW_BEFORE_BUILD_MACOS: brew cask uninstall --force oclint && brew install gcc eigen libomp || true; brew install gcc eigen libomp && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
       CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus


### PR DESCRIPTION
Currently the MacOS wheels are built targetting MacOS 10.13+ (High Sierra). To support older versions of MacOS, we reduce the target to 10.9.