### PR TITLE
Incrementing the version number to 0.13.0rc1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 0.13.0-dev
+# Version 0.13.0rc1
 
 ### New features
 
@@ -8,11 +8,9 @@
 
 * Adds a new module, `thewalrus.random`, to generate random unitary, symplectic and covariance matrices. [#169](https://github.com/XanaduAI/thewalrus/pull/169)
 
-
 * Adds new functions `normal_ordered_expectation`, ` photon_number_expectation` and `photon_number_squared_expectation` in `thewalrus.quantum` to calculate expectation values of products of normal ordered expressions and number operators and their squares. [#175](https://github.com/XanaduAI/thewalrus/pull/175)
 
 * Adds the function `hafnian_sample_graph_rank_one` in `thewalrus.samples` to sample from rank-one adjacency matrices. [#174](https://github.com/XanaduAI/thewalrus/pull/169)
-
 
 ### Improvements
 
@@ -28,9 +26,9 @@
 
 ### Bug fixes
 
-* Fixes Numba decorated functions not rendering properly in the documentation. [#173] (https://github.com/XanaduAI/thewalrus/pull/173)
+* Fixes Numba decorated functions not rendering properly in the documentation. [#173](https://github.com/XanaduAI/thewalrus/pull/173)
 
-* Solves the issue with `quantum` and `samples` not being rendered in the documentation or the TOC. [#173] (https://github.com/XanaduAI/thewalrus/pull/173)
+* Solves the issue with `quantum` and `samples` not being rendered in the documentation or the TOC. [#173](https://github.com/XanaduAI/thewalrus/pull/173)
 
 ### Breaking changes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 ### Breaking changes
 
-* The functions in `thewalrus.fock_gradients` are now separated into functions for the gradients and the gates. Moreover, they are renamed, for instance `Dgate` becomes `displacement` and its gradient is now  `grad_displacement`. [#164](https://github.com/XanaduAI/thewalrus/pull/164/files)
+* The functions in `thewalrus.fock_gradients` are now separated into functions for the gradients and the gates. Moreover, they are renamed, for instance `Dgate` becomes `displacement` and its gradient is now `grad_displacement`. [#164](https://github.com/XanaduAI/thewalrus/pull/164/files)
 
 ### Contributors
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ sphinx==2.2.2
 ipykernel
 nbsphinx
 cython>=0.20
-numba
+numba>=0.49.1
 numpy>=1.9
 sympy>=1.5.1
 repoze.lru>=0.7

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0-dev"
+__version__ = "0.13.0rc1"


### PR DESCRIPTION
**Context:**
A new release-candidate should be released to fix a few compatibility issues.

**Description of the Change:**
The TW version is bumped to 0.13.0rc1.

Also, a minor error is fixed in the changelog and the numba version is set to `>=0.49.1` since that's needed for the docs to build correctly.

**Benefits:**
New release of TW!

**Possible Drawbacks:**
N\A

**Related GitHub Issues:**
N\A
