### PR TITLE
Incrementing the version number to 0.13.0rc2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 0.13.0rc1
+# Version 0.13.0rc2
 
 ### New features
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("thewalrus/_version.py") as f:
 requirements = [
     "numpy",
     "scipy>=1.2.1",
-    "numba>=0.43.1",
+    "numba>=0.49.1",
     "dask[delayed]",
     "sympy>=1.5.1",
     "repoze.lru>=0.7"

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0rc1"
+__version__ = "0.13.0rc2"


### PR DESCRIPTION
**Context:**
A new release-candidate version of TW has been released, and thus a bump to the the next release-candidate is needed.

**Description of the Change:**
The version is updated to 0.13.0rc2

**Benefits:**
Bumps version to next release-candidate.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A