### PR TITLE
Fix bug where quantum and samples were not showing up in the documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,3 +12,4 @@ breathe==4.12.0
 exhale
 version_information
 sphinx-copybutton
+dask[delayed]

--- a/docs/xanadu_theme/static/xanadu.css_t
+++ b/docs/xanadu_theme/static/xanadu.css_t
@@ -48,7 +48,8 @@ body {
   min-height: calc(100% - 50px);
   width: 300px;
   overflow: hidden;
-  box-shadow: 0 0px 0px 0 rgba(0,0,0,.05),0 30px 40px 0px rgba(0,0,0,.2) !important;
+  /*box-shadow: 0 0px 0px 0 rgba(0,0,0,.05),0 30px 40px 0px rgba(0,0,0,.2) !important;*/
+  border-right: 1px #ddd solid;
   background-color: #fff;
   z-index: 2000;
 }
@@ -2035,7 +2036,8 @@ footer.page-footer .footer-copyright {
 
 .navbar {
   background-color: white;
-  box-shadow: -1px 14px 30px -20px rgba(0,0,0,0.61);
+  z-index: 10000;
+  box-shadow: -1px 14px 30px -20px rgba(0,0,0,0.3);
 }
 
 .navbar li.dropdown {


### PR DESCRIPTION
**Context:**

The `quantum` and `samples` modules were not showing up in the documentation, since `dask` was not being installed on readthedocs:

```
WARNING: autodoc: failed to import module 'quantum' from module 'thewalrus'; the following exception was raised:
No module named 'dask'
WARNING: autodoc: failed to import module 'samples' from module 'thewalrus'; the following exception was raised:
No module named 'dask'
```

**Description of the Change:** Adds `dask[delayed]` to `docs/requirements.txt`

**Benefits:** All modules now show in the build documentation.

**Possible Drawbacks:** Unfortunately, I can't build the documentation locally, I get a `Segmentation Fault`.

**Related GitHub Issues:** n/a
