### PR TITLE
Update link to eigen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - image: circleci/python:3.6.8-stretch
     environment:
       CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
-      CIBW_BEFORE_BUILD_LINUX: curl -OsL https://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz && tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
+      CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
       CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - image: circleci/python:3.6.8-stretch
     environment:
       CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
-      CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf 3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
+      CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf eigen-3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
       CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - image: circleci/python:3.6.8-stretch
     environment:
       CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
-      CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf eigen-3.3.7.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
+      CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
       CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus
     steps:

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-The Walrus 
+The Walrus
 ##########
 
 .. image:: https://circleci.com/gh/XanaduAI/thewalrus/tree/master.svg?style=svg&circle-token=209b57390082a2b2fe2cdc9ee49a301ddc29ca5b
@@ -26,8 +26,8 @@ The Walrus
     :target: https://pypi.org/project/thewalrus
 
 .. image:: https://joss.theoj.org/papers/10.21105/joss.01705/status.svg
-	:alt: JOSS - The Journal of Open Source Software
-	:target: https://doi.org/10.21105/joss.01705
+    :alt: JOSS - The Journal of Open Source Software
+    :target: https://doi.org/10.21105/joss.01705
 
 A library for the calculation of hafnians, Hermite polynomials and Gaussian boson sampling. For more information, please see the `documentation <https://the-walrus.readthedocs.io>`_.
 
@@ -101,7 +101,7 @@ Alternatively, you can download the Eigen headers manually:
 .. code-block:: console
 
     $ mkdir ~/.local/eigen3 && cd ~/.local/eigen3
-    $ wget http://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz -O eigen3.tar.gz
+    $ wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz -O eigen3.tar.gz
     $ tar xzf eigen3.tar.gz eigen-eigen-323c052e1731/Eigen --strip-components 1
     $ export EIGEN_INCLUDE_DIR=$HOME/.local/eigen3
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
-      EIGEN_INCLUDE_DIR: C:\eigen-eigen-323c052e1731\
+      EIGEN_INCLUDE_DIR: C:\eigen-3.3.7\
       TEST_TIMEOUT: 1000
       CIBW_BEFORE_BUILD: pip install numpy scipy cython
       CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* *win32"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ matrix:
 
 
 install:
-  - ps: wget http://bitbucket.org/eigen/eigen/get/3.3.7.zip -outfile eigen3.zip
+  - ps: wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip -outfile eigen3.zip
   - cmd: 7z x eigen3.zip -o"C:\" -y > nul
 
 build_script:


### PR DESCRIPTION
**Context:**
Both AppVeyor and CircleCI attempt to download the `eigen3.zip` file from [its Bitbucket repository](https://bitbucket.org/eigen/eigen/get/3.3.7.zip). This has now become obsolete due to [Atlassian no longer supporting Mercurial](https://bitbucket.org/blog/sunsetting-mercurial-support-in-bitbucket).

**Description of the Change:**
`eigen3.zip` is downloaded from [its updated GitLab repository](https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz) instead.

**Benefits:**
Test can now run, and all should be good.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A