### PR TITLE
Add power trace optimization conforming to c++14

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Improvements
 
+* Introduces a new faster and significantly more accurate algorithm to calculate power traces allowing to speed up the calculation of loop hafnians [#199](https://github.com/XanaduAI/thewalrus/pull/199)
+
 ### Bug fixes
 
 ### Breaking changes
@@ -20,7 +22,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Nicolas Quesada
+Nicolas Quesada, Trevor Vincent
 
 ---
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ cache:
 matrix:
   fast_finish: false
 
+image: Visual Studio 2017
 
 install:
   - ps: wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip -outfile eigen3.zip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,7 +101,7 @@ exhale_args = {
     # TIP: if using the sphinx-bootstrap-theme, you need
     # "treeViewIsBootstrap": True,
     "exhaleExecutesDoxygen": True,
-    "exhaleDoxygenStdin":    "INPUT = ../include/stdafx.h ../include/libwalrus.hpp ../include/version.hpp ../include/eigenvalue_hafnian.hpp ../include/hafnian_approx.hpp ../include/recursive_hafnian.hpp ../include/repeated_hafnian.hpp  ../include/torontonian.hpp ../include/permanent.hpp ../include/hermite_multidimensional.hpp",
+    "exhaleDoxygenStdin":    "INPUT = ../include/stdafx.h ../include/libwalrus.hpp ../include/version.hpp ../include/eigenvalue_hafnian.hpp ../include/hafnian_approx.hpp ../include/recursive_hafnian.hpp ../include/repeated_hafnian.hpp  ../include/torontonian.hpp ../include/permanent.hpp ../include/hermite_multidimensional.hpp ../include/powtrace.hpp",
     # "exhaleUseDoxyfile": True
 }
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 sphinxcontrib-bibtex
-sphinx==2.2.2
+sphinx==1.8.5
 ipykernel
 nbsphinx
 cython>=0.20

--- a/docs/xanadu_theme/static/xanadu.css_t
+++ b/docs/xanadu_theme/static/xanadu.css_t
@@ -186,8 +186,8 @@ tt {
 }
 
 code, pre {
-  line-height: 23px;
-  margin: 20px 0;
+  line-height: 23px !important;
+  margin: 20px 0 !important;
   word-wrap: normal;
   background-color: #fff;
 }

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,7 +14,7 @@
 EIGEN_INCLUDE_DIR?=/usr/include/eigen3
 
 CC=g++
-CFLAGS=-std=c++11 -O3 -Wall -I/usr/include -I../include -I$(EIGEN_INCLUDE_DIR) -fopenmp -march=native
+CFLAGS=-std=c++14 -O3 -Wall -I/usr/include -I../include -I$(EIGEN_INCLUDE_DIR) -fopenmp -march=native
 LFLAGS=-L/usr/lib -lm -fopenmp
 
 all: example-cpp

--- a/include/eigenvalue_hafnian.hpp
+++ b/include/eigenvalue_hafnian.hpp
@@ -17,321 +17,227 @@
  * *A faster hafnian formula for complex matrices and its benchmarking
  * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498)
  */
-#pragma once
-#include <stdafx.h>
 
-#ifdef LAPACKE
-#define EIGEN_SUPERLU_SUPPORT
-#define EIGEN_USE_BLAS
-#define EIGEN_USE_LAPACKE
+// #include <Eigen/Eigenvalues>
 
-#define LAPACK_COMPLEX_CUSTOM
-#define lapack_complex_float std::complex<float>
-#define lapack_complex_double std::complex<double>
-#endif
-
-#include <Eigen/Eigenvalues>
+#include "stdafx.h"
+#include "powtrace.hpp"
 
 namespace libwalrus {
 
-/**
- * Given a complex matrix \f$z\f$ of dimensions \f$n\times n\f$, it calculates
- * \f$Tr(z^j)~\forall~1\leq j\leq l\f$.
- *
- * @param z a flattened complex vector of size \f$n^2\f$, representing an
- *       \f$n\times n\f$ row-ordered matrix.
- * @param n size of the matrix `z`.
- * @param l maximum matrix power when calculating the power trace.
- * @return a vector containing the power traces of matrix `z` to power
- *       \f$1\leq j \leq l\f$.
- */
-inline vec_complex powtrace(vec_complex &z, int n, int l) {
-    vec_complex traces(l, 0.0);
-    vec_complex vals(n, 0.0);
-    vec_complex pvals(n, 0.0);
-
-    Eigen::MatrixXcd A = Eigen::Map<Eigen::MatrixXcd, Eigen::Unaligned>(z.data(), n, n);
-    Eigen::ComplexEigenSolver<Eigen::MatrixXcd> solver(A, false);
-    Eigen::MatrixXcd evals = solver.eigenvalues();
-    vals = vec_complex(evals.data(), evals.data() + evals.size());
-
-    double_complex sum;
-    int i, j;
-
-    for (j = 0; j < n; j++) {
-        pvals[j] = vals[j];
-    }
-
-    for (i = 0; i < l; i++) {
-        sum = 0.0;
-        for (j = 0; j < n; j++) {
-            sum += pvals[j];
-        }
-        traces[i] = sum;
-        for (j = 0; j < n; j++) {
-            pvals[j] = pvals[j] * vals[j];
-        }
-    }
-
-    return traces;
-};
-
-/**
-* Given a real matrix \f$z\f$ of dimensions \f$n\times n\f$, it calculates
-* \f$Tr(z^j)~\forall~1\leq j\leq l\f$.
-*
-* @param z a flattened complex vector of size \f$n^2\f$, representing an
-*       \f$n\times n\f$ row-ordered matrix.
-* @param n size of the matrix `z`.
-* @param l maximum matrix power when calculating the power trace.
-* @return a vector containing the power traces of matrix `z` to power
-*       \f$1\leq j \leq l\f$.
-*/
-inline vec_double powtrace(vec_double &z, int n, int l) {
-    vec_double traces(l, 0.0);
-    vec_complex vals(n, 0.0);
-    vec_complex pvals(n, 0.0);
-
-    Eigen::MatrixXd A = Eigen::Map<Eigen::MatrixXd, Eigen::Unaligned>(z.data(), n, n);
-    Eigen::EigenSolver<Eigen::MatrixXd> solver(A, false);
-    Eigen::MatrixXcd evals = solver.eigenvalues();
-    vals = vec_complex(evals.data(), evals.data() + evals.size());
-
-    double_complex sum;
-    int i, j;
-
-    for (j = 0; j < n; j++) {
-        pvals[j] = vals[j];
-    }
-    for (i = 0; i < l; i++) {
-        sum = 0.0;
-        for (j = 0; j < n; j++) {
-            sum += pvals[j];
-        }
-        traces[i] = sum.real();
-        for (j = 0; j < n; j++) {
-            pvals[j] = pvals[j] * vals[j];
-        }
-    }
-
-    return traces;
-};
-
-
-
-/**
- * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
- * the Cygan and Pilipczuk formula for the hafnian of matrix `mat`.
- *
- * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full hafnian is calculated.
- *
- * This function uses OpenMP (if available) to parallelize the reduction.
- *
- * @param mat vector representing the flattened matrix
- * @param n size of the matrix
- * @param X initial index of the partial sum
- * @param chunksize length of the partial sum
- * @return the partial sum for hafnian
- */
-template <typename T>
-inline T do_chunk(std::vector<T> &mat, int n, unsigned long long int X, unsigned long long int chunksize) {
+  /**
+   * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
+   * the Cygan and Pilipczuk formula for the hafnian of matrix `mat`.
+   *
+   * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full hafnian is calculated.
+   *
+   * This function uses OpenMP (if available) to parallelize the reduction.
+   *
+   * @param mat vector representing the flattened matrix
+   * @param n size of the matrix
+   * @param X initial index of the partial sum
+   * @param chunksize length of the partial sum
+   * @return the partial sum for hafnian
+   */
+  template <typename T>
+  inline T do_chunk(std::vector<T> &mat, int n, unsigned long long int X, unsigned long long int chunksize) {
     // This function calculates adds parts X to X+chunksize of Cygan and Pilipczuk formula for the
     // Hafnian of matrix mat
 
     T res = 0.0;
 
-    #pragma omp parallel for
+#pragma omp parallel for
     for (unsigned long long int x = X; x < X + chunksize; x++) {
-        T summand = 0.0;
+      T summand = 0.0;
 
-        Byte m = n / 2;
-        int i, j, k;
-        T factor, powfactor;
+      Byte m = n / 2;
+      int i, j, k;
+      T factor, powfactor;
 
-        char* dst = new char[m];
-        Byte* pos = new Byte[n];
-        dec2bin(dst, x, m);
-        Byte sum = find2(dst, m, pos);
-        delete [] dst;
+      char* dst = new char[m];
+      Byte* pos = new Byte[n];
+      dec2bin(dst, x, m);
+      Byte sum = find2(dst, m, pos);
+      delete [] dst;
 
-        std::vector<T> B(sum * sum, 0.0);
+      std::vector<T> B(sum * sum, 0.0);
 
-        for (i = 0; i < sum; i++) {
-            for (j = 0; j < sum; j++) {
-                B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
-            }
-        }
-        delete [] pos;
+      for (i = 0; i < sum; i++) {
+	for (j = 0; j < sum; j++) {
+	  B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
+	}
+      }
+      delete [] pos;
 
-        std::vector<T> traces(m, 0.0);
-        if (sum != 0) {
-            traces = powtrace(B, sum, m);
-        }
+      std::vector<T> traces(m, 0.0);
+      if (sum != 0) {
+	traces = powtrace(B, sum, m);
+      }
 
-        char cnt = 1;
-        Byte cntindex = 0;
+      char cnt = 1;
+      Byte cntindex = 0;
 
-        std::vector<T> comb(2 * (m + 1), 0.0);
-        comb[0] = 1.0;
+      std::vector<T> comb(2 * (m + 1), 0.0);
+      comb[0] = 1.0;
 
-        for (i = 1; i <= n / 2; i++) {
-            factor = traces[i - 1] / (2.0 * i);
-            powfactor = 1.0;
+      for (i = 1; i <= n / 2; i++) {
+	factor = traces[i - 1] / (2.0 * i);
+	powfactor = 1.0;
 
-            cnt = -cnt;
-            cntindex = (1 + cnt) / 2;
-            for (j = 0; j < n / 2 + 1; j++) {
-                comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
-            }
-            for (j = 1; j <= (n / (2 * i)); j++) {
-                powfactor = powfactor * factor / (1.0 * j);
-                for (k = i * j + 1; k <= n / 2 + 1; k++) {
-                    comb[(m + 1) * (1 - cntindex) + k - 1] += comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
-                }
-            }
-        }
-        if (((sum / 2) % 2) == (n / 2 % 2)) {
-            summand = comb[(m + 1) * (1 - cntindex) + n / 2];
-        }
-        else {
-            summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
-        }
-        #pragma omp critical
-        res += summand;
+	cnt = -cnt;
+	cntindex = (1 + cnt) / 2;
+	for (j = 0; j < n / 2 + 1; j++) {
+	  comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
+	}
+	for (j = 1; j <= (n / (2 * i)); j++) {
+	  powfactor = powfactor * factor / (1.0 * j);
+	  for (k = i * j + 1; k <= n / 2 + 1; k++) {
+	    comb[(m + 1) * (1 - cntindex) + k - 1] += comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
+	  }
+	}
+      }
+      if (((sum / 2) % 2) == (n / 2 % 2)) {
+	summand = comb[(m + 1) * (1 - cntindex) + n / 2];
+      }
+      else {
+	summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
+      }
+#pragma omp critical
+      res += summand;
     }
 
     return res;
-}
+  }
 
-/**
- * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
- * the Cygan and Pilipczuk formula for the loop hafnian of matrix `mat`.
- *
- * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full loop hafnian is calculated.
- *
- * This function uses OpenMP (if available) to parallelize the reduction.
- *
- * @param mat vector representing the flattened matrix
- * @param C contains the diagonal elements of matrix ``z``
- * @param D the diagonal elements of matrix ``z``, with every consecutive pair
- *      swapped (i.e., ``C[0]==D[1]``, ``C[1]==D[0]``, ``C[2]==D[3]``,
- *      ``C[3]==D[2]``, etc.).
- * @param n size of the matrix
- * @param X initial index of the partial sum
- * @param chunksize length of the partial sum
- * @return the partial sum for the loop hafnian
- */
-template <typename T>
-inline T do_chunk_loops(std::vector<T> &mat, std::vector<T> &C, std::vector<T> &D, int n, unsigned long long int X, unsigned long long int chunksize) {
+  /**
+   * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
+   * the Cygan and Pilipczuk formula for the loop hafnian of matrix `mat`.
+   *
+   * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full loop hafnian is calculated.
+   *
+   * This function uses OpenMP (if available) to parallelize the reduction.
+   *
+   * @param mat vector representing the flattened matrix
+   * @param C contains the diagonal elements of matrix ``z``
+   * @param D the diagonal elements of matrix ``z``, with every consecutive pair
+   *      swapped (i.e., ``C[0]==D[1]``, ``C[1]==D[0]``, ``C[2]==D[3]``,
+   *      ``C[3]==D[2]``, etc.).
+   * @param n size of the matrix
+   * @param X initial index of the partial sum
+   * @param chunksize length of the partial sum
+   * @return the partial sum for the loop hafnian
+   */
+  template <typename T>
+  inline T do_chunk_loops(std::vector<T> &mat, std::vector<T> &C, std::vector<T> &D, int n, unsigned long long int X, unsigned long long int chunksize) {
 
     T res = 0.0;
 
-    #pragma omp parallel for
+#pragma omp parallel for
     for (unsigned long long int x = X * chunksize; x < (X + 1)*chunksize; x++) {
-        T summand = 0.0;
+      T summand = 0.0;
 
-        Byte m = n / 2;
-        int i, j, k;
-        T factor, powfactor;
+      Byte m = n / 2;
+      int i, j, k;
+      T factor, powfactor;
 
-        char* dst = new char[m];
-        Byte* pos = new Byte[n];
-        dec2bin(dst, x, m);
-        Byte sum = find2(dst, m, pos);
-        delete [] dst;
+      char* dst = new char[m];
+      Byte* pos = new Byte[n];
+      dec2bin(dst, x, m);
+      Byte sum = find2(dst, m, pos);
+      delete [] dst;
 
-        std::vector<T> B(sum * sum, 0.0), B_powtrace(sum * sum, 0.0);
-        std::vector<T> C1(sum, 0.0), D1(sum, 0.0);
+      std::vector<T> B(sum * sum, 0.0), B_powtrace(sum * sum, 0.0);
+      std::vector<T> C1(sum, 0.0), D1(sum, 0.0);
 
-        for (i = 0; i < sum; i++) {
-            for (j = 0; j < sum; j++) {
-                B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
-                B_powtrace[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
-            }
-            C1[i] = C[pos[i]];
-            D1[i] = D[pos[i]];
-        }
-        delete [] pos;
+      for (i = 0; i < sum; i++) {
+	for (j = 0; j < sum; j++) {
+	  B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
+	  B_powtrace[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
+	}
+	C1[i] = C[pos[i]];
+	D1[i] = D[pos[i]];
+      }
+      delete [] pos;
 
-        std::vector<T> traces(m, 0.0);
-        if (sum != 0) {
-            traces = powtrace(B, sum, m);
-        }
+      std::vector<T> traces(m, 0.0);
+      if (sum != 0) {
+	traces = powtrace(B, sum, m);
+      }
 
-        char cnt = 1;
-        Byte cntindex = 0;
+      char cnt = 1;
+      Byte cntindex = 0;
 
-        std::vector<T> comb(2 * (m + 1), 0.0);
-        comb[0] = 1.0;
+      std::vector<T> comb(2 * (m + 1), 0.0);
+      comb[0] = 1.0;
 
-        for (i = 1; i <= n / 2; i++) {
-            factor = traces[i - 1] / (2.0 * i);
-            T tmpn = 0.0;
+      for (i = 1; i <= n / 2; i++) {
+	factor = traces[i - 1] / (2.0 * i);
+	T tmpn = 0.0;
 
-            for (int i = 0; i < sum; i++) {
-                tmpn += C1[i] * D1[i];
-            }
+	for (int i = 0; i < sum; i++) {
+	  tmpn += C1[i] * D1[i];
+	}
 
-            factor += 0.5 * tmpn;
-            std::vector<T> tmp_c1(sum, 0.0);
+	factor += 0.5 * tmpn;
+	std::vector<T> tmp_c1(sum, 0.0);
 
-            T tmp = 0.0;
+	T tmp = 0.0;
 
-            for (int i = 0; i < sum; i++) {
-                tmp = 0.0;
+	for (int i = 0; i < sum; i++) {
+	  tmp = 0.0;
 
-                for (int j = 0; j < sum; j++) {
-                    tmp += C1[j] * B[j * sum + i];
-                }
+	  for (int j = 0; j < sum; j++) {
+	    tmp += C1[j] * B[j * sum + i];
+	  }
 
-                tmp_c1[i] = tmp;
-            }
+	  tmp_c1[i] = tmp;
+	}
 
-            for (int i = 0; i < sum; i++) {
-                C1[i] = tmp_c1[i];
-            }
+	for (int i = 0; i < sum; i++) {
+	  C1[i] = tmp_c1[i];
+	}
 
-            powfactor = 1.0;
+	powfactor = 1.0;
 
-            cnt = -cnt;
-            cntindex = (1 + cnt) / 2;
-            for (j = 0; j < n / 2 + 1; j++) {
-                comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
-            }
+	cnt = -cnt;
+	cntindex = (1 + cnt) / 2;
+	for (j = 0; j < n / 2 + 1; j++) {
+	  comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
+	}
 
-            for (j = 1; j <= (n / (2 * i)); j++) {
-                powfactor = powfactor * factor / (1.0 * j);
-                for (k = i * j + 1; k <= n / 2 + 1; k++) {
-                    comb[(m + 1) * (1 - cntindex) + k - 1] = comb[(m + 1) * (1 - cntindex) + k - 1] + comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
-                }
-            }
-        }
+	for (j = 1; j <= (n / (2 * i)); j++) {
+	  powfactor = powfactor * factor / (1.0 * j);
+	  for (k = i * j + 1; k <= n / 2 + 1; k++) {
+	    comb[(m + 1) * (1 - cntindex) + k - 1] = comb[(m + 1) * (1 - cntindex) + k - 1] + comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
+	  }
+	}
+      }
 
-        if (((sum / 2) % 2) == (n / 2 % 2)) {
-            summand = comb[(m + 1) * (1 - cntindex) + n / 2];
-        }
-        else {
-            summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
-        }
-        #pragma omp critical
-        res += summand;
+      if (((sum / 2) % 2) == (n / 2 % 2)) {
+	summand = comb[(m + 1) * (1 - cntindex) + n / 2];
+      }
+      else {
+	summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
+      }
+#pragma omp critical
+      res += summand;
     }
 
     return res;
-}
+  }
 
 
-/**
-* Returns the hafnian of a matrix using the algorithm described in
-* *A faster hafnian formula for complex matrices and its benchmarking
-* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-*
-* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-*       row-ordered symmetric matrix.
-* @return hafnian of the input matrix
-*/
-template <typename T>
-inline T hafnian(std::vector<T> &mat) {
+  /**
+   * Returns the hafnian of a matrix using the algorithm described in
+   * *A faster hafnian formula for complex matrices and its benchmarking
+   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+   *
+   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+   *       row-ordered symmetric matrix.
+   * @return hafnian of the input matrix
+   */
+  template <typename T>
+  inline T hafnian(std::vector<T> &mat) {
     int n = std::sqrt(static_cast<double>(mat.size()));
     assert(n % 2 == 0);
 
@@ -347,20 +253,20 @@ inline T hafnian(std::vector<T> &mat) {
     T haf;
     haf = do_chunk(mat, n, rank, chunksize);
     return  haf;
-}
+  }
 
 
-/**
-* Returns the loop hafnian of a matrix using the algorithm described in
-* *A faster hafnian formula for complex matrices and its benchmarking
-* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-*
-* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-*       row-ordered symmetric matrix.
-* @return hafnian of the input matrix
-*/
-template <typename T>
-inline T loop_hafnian(std::vector<T> &mat) {
+  /**
+   * Returns the loop hafnian of a matrix using the algorithm described in
+   * *A faster hafnian formula for complex matrices and its benchmarking
+   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+   *
+   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+   *       row-ordered symmetric matrix.
+   * @return hafnian of the input matrix
+   */
+  template <typename T>
+  inline T loop_hafnian(std::vector<T> &mat) {
     int n = std::sqrt(static_cast<double>(mat.size()));
     assert(n % 2 == 0);
 
@@ -376,153 +282,153 @@ inline T loop_hafnian(std::vector<T> &mat) {
     unsigned long long int rank = 0;
 
     for (int i = 0; i < n; i++) {
-        D[i] = mat[i * n + i];
+      D[i] = mat[i * n + i];
     }
 
     for (int i = 0; i < n; i += 2) {
-        C[i] = D[i + 1];
-        C[i + 1] = D[i];
+      C[i] = D[i + 1];
+      C[i + 1] = D[i];
     }
 
     T haf;
     haf = do_chunk_loops(mat, C, D, n, rank, chunksize);
     return  haf;
-}
+  }
 
 
-/**
-* Returns the hafnian of a matrix using the algorithm described in
-* *A faster hafnian formula for complex matrices and its benchmarking
-* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-*
-* This is a wrapper around the templated function hafnian() for Python
-* integration. It accepts and returns complex double numeric types, and
-* returns sensible values for empty and non-even matrices.
-*
-* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-*       row-ordered symmetric matrix.
-* @return hafnian of the input matrix
-*/
-std::complex<double> hafnian_eigen(std::vector<std::complex<double>> &mat) {
+  /**
+   * Returns the hafnian of a matrix using the algorithm described in
+   * *A faster hafnian formula for complex matrices and its benchmarking
+   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+   *
+   * This is a wrapper around the templated function hafnian() for Python
+   * integration. It accepts and returns complex double numeric types, and
+   * returns sensible values for empty and non-even matrices.
+   *
+   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+   *       row-ordered symmetric matrix.
+   * @return hafnian of the input matrix
+   */
+  std::complex<double> hafnian_eigen(std::vector<std::complex<double>> &mat) {
     std::vector<std::complex<double>> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     std::complex<double> haf;
 
     if (n == 0)
-        haf = std::complex<double>(1.0, 0.0);
+      haf = std::complex<double>(1.0, 0.0);
     else if (n % 2 != 0)
-        haf = std::complex<double>(0.0, 0.0);
+      haf = std::complex<double>(0.0, 0.0);
     else
-        haf = hafnian(matq);
+      haf = hafnian(matq);
 
     return haf;
-}
+  }
 
 
-/**
-* Returns the hafnian of a matrix using the algorithm described in
-* *A faster hafnian formula for complex matrices and its benchmarking
-* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-*
-* This is a wrapper around the templated function hafnian() for Python
-* integration. It accepts and returns double numeric types, and
-* returns sensible values for empty and non-even matrices.
-*
-* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-*       row-ordered symmetric matrix.
-* @return hafnian of the input matrix
-*/
-double hafnian_eigen(std::vector<double> &mat) {
+  /**
+   * Returns the hafnian of a matrix using the algorithm described in
+   * *A faster hafnian formula for complex matrices and its benchmarking
+   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+   *
+   * This is a wrapper around the templated function hafnian() for Python
+   * integration. It accepts and returns double numeric types, and
+   * returns sensible values for empty and non-even matrices.
+   *
+   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+   *       row-ordered symmetric matrix.
+   * @return hafnian of the input matrix
+   */
+  double hafnian_eigen(std::vector<double> &mat) {
     std::vector<double> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     double haf;
 
     if (n == 0)
-        haf = 1.0;
+      haf = 1.0;
     else if (n % 2 != 0)
-        haf = 0.0;
+      haf = 0.0;
     else
-        haf = static_cast<double>(hafnian(matq));
+      haf = static_cast<double>(hafnian(matq));
 
     return haf;
-}
+  }
 
 
-/**
-* Returns the loop hafnian of a matrix using the algorithm described in
-* *A faster hafnian formula for complex matrices and its benchmarking
-* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-*
-* This is a wrapper around the templated function libwalrus::loop_hafnian() for Python
-* integration. It accepts and returns complex double numeric types, and
-* returns sensible values for empty and non-even matrices.
-*
-* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-*       row-ordered symmetric matrix.
-* @return loop hafnian of the input matrix
-*/
-std::complex<double> loop_hafnian_eigen(std::vector<std::complex<double>> &mat) {
+  /**
+   * Returns the loop hafnian of a matrix using the algorithm described in
+   * *A faster hafnian formula for complex matrices and its benchmarking
+   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+   *
+   * This is a wrapper around the templated function libwalrus::loop_hafnian() for Python
+   * integration. It accepts and returns complex double numeric types, and
+   * returns sensible values for empty and non-even matrices.
+   *
+   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+   *       row-ordered symmetric matrix.
+   * @return loop hafnian of the input matrix
+   */
+  std::complex<double> loop_hafnian_eigen(std::vector<std::complex<double>> &mat) {
     std::vector<std::complex<double>> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     std::complex<double> haf;
     std::vector<std::complex<double>> matq2((n + 1) * (n + 1), std::complex<double>(0.0, 0.0));
 
     if (n == 0)
-        haf = std::complex<double>(1.0, 0.0);
+      haf = std::complex<double>(1.0, 0.0);
     else if (n % 2 != 0) {
-        for (int i = 0; i < n; i++) {
-            for (int j = 0; j < n; j++) {
-                matq2[i * (n + 1) + j] = matq[i * n + j];
-            }
-        }
-        matq2[(n + 1) * (n + 1) - 1] = std::complex<double>(1.0, 0.0);
+      for (int i = 0; i < n; i++) {
+	for (int j = 0; j < n; j++) {
+	  matq2[i * (n + 1) + j] = matq[i * n + j];
+	}
+      }
+      matq2[(n + 1) * (n + 1) - 1] = std::complex<double>(1.0, 0.0);
 
 
-        haf = loop_hafnian(matq2);
+      haf = loop_hafnian(matq2);
     }
     else
-        haf = loop_hafnian(matq);
+      haf = loop_hafnian(matq);
 
     return haf;
-}
+  }
 
 
-/**
-* Returns the loop hafnian of a matrix using the algorithm described in
-* *A faster hafnian formula for complex matrices and its benchmarking
-* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-*
-* This is a wrapper around the templated function loop_hafnian() for Python
-* integration. It accepts and returns double numeric types, and
-* returns sensible values for empty and non-even matrices.
-*
-* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-*       row-ordered symmetric matrix.
-* @return loop hafnian of the input matrix
-*/
-double loop_hafnian_eigen(std::vector<double> &mat) {
+  /**
+   * Returns the loop hafnian of a matrix using the algorithm described in
+   * *A faster hafnian formula for complex matrices and its benchmarking
+   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+   *
+   * This is a wrapper around the templated function loop_hafnian() for Python
+   * integration. It accepts and returns double numeric types, and
+   * returns sensible values for empty and non-even matrices.
+   *
+   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+   *       row-ordered symmetric matrix.
+   * @return loop hafnian of the input matrix
+   */
+  double loop_hafnian_eigen(std::vector<double> &mat) {
     std::vector<double> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     double haf;
     std::vector<double> matq2((n + 1) * (n + 1), 0.0);
 
     if (n == 0)
-        haf = 1.0;
+      haf = 1.0;
     else if (n % 2 != 0) {
-        for (int i = 0; i < n; i++) {
-            for (int j = 0; j < n; j++) {
-                matq2[i * (n + 1) + j] = mat[i * n + j];
-            }
-        }
-        matq2[(n + 1) * (n + 1) - 1] = 1.0;
+      for (int i = 0; i < n; i++) {
+	for (int j = 0; j < n; j++) {
+	  matq2[i * (n + 1) + j] = mat[i * n + j];
+	}
+      }
+      matq2[(n + 1) * (n + 1) - 1] = 1.0;
 
 
-        haf = loop_hafnian(matq2);
+      haf = loop_hafnian(matq2);
     }
     else
-        haf = static_cast<double>(loop_hafnian(matq));
+      haf = static_cast<double>(loop_hafnian(matq));
 
     return haf;
-}
+  }
 
 }

--- a/include/eigenvalue_hafnian.hpp
+++ b/include/eigenvalue_hafnian.hpp
@@ -81,7 +81,7 @@ inline T do_chunk(std::vector<T> &mat, int n, unsigned long long int X, unsigned
         comb[0] = 1.0;
 
         for (i = 1; i <= n / 2; i++) {
-            factor = traces[i - 1] / (2.0 * i);
+            factor = traces[i - 1] / static_cast<T>(2.0 * i);
             powfactor = 1.0;
 
             cnt = -cnt;
@@ -171,14 +171,14 @@ inline T do_chunk_loops(std::vector<T> &mat, std::vector<T> &C, std::vector<T> &
         comb[0] = 1.0;
 
         for (i = 1; i <= n / 2; i++) {
-            factor = traces[i - 1] / (2.0 * i);
+            factor = traces[i - 1] / static_cast<T> (2.0 * i);
             T tmpn = 0.0;
 
             for (int i = 0; i < sum; i++) {
                 tmpn += C1[i] * D1[i];
             }
 
-            factor += 0.5 * tmpn;
+            factor += static_cast<T> (0.5) * tmpn;
             std::vector<T> tmp_c1(sum, 0.0);
 
             T tmp = 0.0;
@@ -206,7 +206,7 @@ inline T do_chunk_loops(std::vector<T> &mat, std::vector<T> &C, std::vector<T> &
             }
 
             for (j = 1; j <= (n / (2 * i)); j++) {
-                powfactor = powfactor * factor / (1.0 * j);
+                powfactor = powfactor * factor / static_cast<T> (1.0 * j);
                 for (k = i * j + 1; k <= n / 2 + 1; k++) {
                     comb[(m + 1) * (1 - cntindex) + k - 1] = comb[(m + 1) * (1 - cntindex) + k - 1] + comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
                 }
@@ -429,6 +429,72 @@ double loop_hafnian_eigen(std::vector<double> &mat) {
         haf = static_cast<double>(loop_hafnian(matq));
 
     return haf;
+}
+
+/**
+ * \rst
+ *
+ * Returns the loop hafnian of a matrix using the trace algorithm described in
+ * *A faster hafnian formula and its benchmarking in a supercomputer* :cite:`bjorklund2019faster`,
+ *
+ * \endrst
+ *
+ * This is a wrapper around the templated function `libwalrus::loop_hafnian` for Python
+ * integration. It accepts and returns complex double numeric types, and
+ * returns sensible values for empty and non-even matrices.
+ *
+ * In addition, this wrapper function automatically casts all matrices
+ * to type `complex<long double>`, allowing for greater precision than supported
+ * by Python and NumPy.
+ *
+ * @param mat vector representing the flattened matrix
+ * @return the hafnian
+ */
+
+std::complex<double> loop_hafnian_quad(std::vector<std::complex<double>> &mat) {
+    std::vector<std::complex<long double>> matq(mat.begin(), mat.end());
+    int n = std::sqrt(static_cast<double>(mat.size()));
+    std::complex<long double> haf;
+
+    if (n == 0)
+        haf = std::complex<double>(1.0, 0.0);
+    else
+        haf = loop_hafnian(matq);
+
+    return static_cast<std::complex<double>>(haf);
+}
+
+/**
+ * \rst
+ *
+ * Returns the loop hafnian of a matrix using the trace algorithm described in
+ * *A faster hafnian formula and its benchmarking in a supercomputer* :cite:`bjorklund2019faster`,
+ *
+ * \endrst
+ *
+ * This is a wrapper around the templated function `libwalrus::loop_hafnian` for Python
+ * integration. It accepts and returns double numeric types, and
+ * returns sensible values for empty and non-even matrices.
+ *
+ * In addition, this wrapper function automatically casts all matrices
+ * to type `long double`, allowing for greater precision than supported
+ * by Python and NumPy.
+ *
+ * @param mat vector representing the flattened matrix
+ * @return the hafnian
+ */
+
+double loop_hafnian_quad(std::vector<double> &mat) {
+    std::vector<long double> matq(mat.begin(), mat.end());
+    int n = std::sqrt(static_cast<double>(mat.size()));
+    long double haf;
+
+    if (n == 0)
+        haf = 1.0;
+    else
+        haf = loop_hafnian(matq);
+
+    return static_cast<double>(haf);
 }
 
 }

--- a/include/eigenvalue_hafnian.hpp
+++ b/include/eigenvalue_hafnian.hpp
@@ -257,7 +257,7 @@ inline T hafnian(std::vector<T> &mat) {
 
 
 /**
- * Returns the loop hafnian of a matrix using the algorithm described in
+* Returns the loop hafnian of a matrix using the algorithm described in
  * *A faster hafnian formula for complex matrices and its benchmarking
  * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
  *

--- a/include/eigenvalue_hafnian.hpp
+++ b/include/eigenvalue_hafnian.hpp
@@ -18,7 +18,6 @@
  * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498)
  */
 
-// #include <Eigen/Eigenvalues>
 
 #include "stdafx.h"
 #include "powtrace.hpp"

--- a/include/eigenvalue_hafnian.hpp
+++ b/include/eigenvalue_hafnian.hpp
@@ -228,14 +228,14 @@ inline T do_chunk_loops(std::vector<T> &mat, std::vector<T> &C, std::vector<T> &
 
 
 /**
- * Returns the hafnian of a matrix using the algorithm described in
- * *A faster hafnian formula for complex matrices and its benchmarking
- * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
- *
- * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
- *       row-ordered symmetric matrix.
- * @return hafnian of the input matrix
- */
+* Returns the hafnian of a matrix using the algorithm described in
+* *A faster hafnian formula for complex matrices and its benchmarking
+* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+*
+* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+*       row-ordered symmetric matrix.
+* @return hafnian of the input matrix
+*/
 template <typename T>
 inline T hafnian(std::vector<T> &mat) {
     int n = std::sqrt(static_cast<double>(mat.size()));
@@ -258,13 +258,13 @@ inline T hafnian(std::vector<T> &mat) {
 
 /**
 * Returns the loop hafnian of a matrix using the algorithm described in
- * *A faster hafnian formula for complex matrices and its benchmarking
- * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
- *
- * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
- *       row-ordered symmetric matrix.
- * @return hafnian of the input matrix
- */
+* *A faster hafnian formula for complex matrices and its benchmarking
+* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+*
+* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+*       row-ordered symmetric matrix.
+* @return hafnian of the input matrix
+*/
 template <typename T>
 inline T loop_hafnian(std::vector<T> &mat) {
     int n = std::sqrt(static_cast<double>(mat.size()));
@@ -297,18 +297,18 @@ inline T loop_hafnian(std::vector<T> &mat) {
 
 
 /**
- * Returns the hafnian of a matrix using the algorithm described in
- * *A faster hafnian formula for complex matrices and its benchmarking
- * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
- *
- * This is a wrapper around the templated function hafnian() for Python
- * integration. It accepts and returns complex double numeric types, and
- * returns sensible values for empty and non-even matrices.
- *
- * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
- *       row-ordered symmetric matrix.
- * @return hafnian of the input matrix
- */
+* Returns the hafnian of a matrix using the algorithm described in
+* *A faster hafnian formula for complex matrices and its benchmarking
+* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+*
+* This is a wrapper around the templated function hafnian() for Python
+* integration. It accepts and returns complex double numeric types, and
+* returns sensible values for empty and non-even matrices.
+*
+* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+*       row-ordered symmetric matrix.
+* @return hafnian of the input matrix
+*/
 std::complex<double> hafnian_eigen(std::vector<std::complex<double>> &mat) {
     std::vector<std::complex<double>> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
@@ -326,18 +326,18 @@ std::complex<double> hafnian_eigen(std::vector<std::complex<double>> &mat) {
 
 
 /**
- * Returns the hafnian of a matrix using the algorithm described in
- * *A faster hafnian formula for complex matrices and its benchmarking
- * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
- *
- * This is a wrapper around the templated function hafnian() for Python
- * integration. It accepts and returns double numeric types, and
- * returns sensible values for empty and non-even matrices.
- *
- * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
- *       row-ordered symmetric matrix.
- * @return hafnian of the input matrix
- */
+* Returns the hafnian of a matrix using the algorithm described in
+* *A faster hafnian formula for complex matrices and its benchmarking
+* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+*
+* This is a wrapper around the templated function hafnian() for Python
+* integration. It accepts and returns double numeric types, and
+* returns sensible values for empty and non-even matrices.
+*
+* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+*       row-ordered symmetric matrix.
+* @return hafnian of the input matrix
+*/
 double hafnian_eigen(std::vector<double> &mat) {
     std::vector<double> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
@@ -355,18 +355,18 @@ double hafnian_eigen(std::vector<double> &mat) {
 
 
 /**
- * Returns the loop hafnian of a matrix using the algorithm described in
- * *A faster hafnian formula for complex matrices and its benchmarking
- * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
- *
- * This is a wrapper around the templated function libwalrus::loop_hafnian() for Python
- * integration. It accepts and returns complex double numeric types, and
- * returns sensible values for empty and non-even matrices.
- *
- * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
- *       row-ordered symmetric matrix.
- * @return loop hafnian of the input matrix
- */
+* Returns the loop hafnian of a matrix using the algorithm described in
+* *A faster hafnian formula for complex matrices and its benchmarking
+* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+*
+* This is a wrapper around the templated function libwalrus::loop_hafnian() for Python
+* integration. It accepts and returns complex double numeric types, and
+* returns sensible values for empty and non-even matrices.
+*
+* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+*       row-ordered symmetric matrix.
+* @return loop hafnian of the input matrix
+*/
 std::complex<double> loop_hafnian_eigen(std::vector<std::complex<double>> &mat) {
     std::vector<std::complex<double>> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
@@ -394,18 +394,18 @@ std::complex<double> loop_hafnian_eigen(std::vector<std::complex<double>> &mat) 
 
 
 /**
- * Returns the loop hafnian of a matrix using the algorithm described in
- * *A faster hafnian formula for complex matrices and its benchmarking
- * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
- *
- * This is a wrapper around the templated function loop_hafnian() for Python
- * integration. It accepts and returns double numeric types, and
- * returns sensible values for empty and non-even matrices.
- *
- * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
- *       row-ordered symmetric matrix.
- * @return loop hafnian of the input matrix
- */
+* Returns the loop hafnian of a matrix using the algorithm described in
+* *A faster hafnian formula for complex matrices and its benchmarking
+* on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+*
+* This is a wrapper around the templated function loop_hafnian() for Python
+* integration. It accepts and returns double numeric types, and
+* returns sensible values for empty and non-even matrices.
+*
+* @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+*       row-ordered symmetric matrix.
+* @return loop hafnian of the input matrix
+*/
 double loop_hafnian_eigen(std::vector<double> &mat) {
     std::vector<double> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));

--- a/include/eigenvalue_hafnian.hpp
+++ b/include/eigenvalue_hafnian.hpp
@@ -25,219 +25,219 @@
 
 namespace libwalrus {
 
-  /**
-   * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
-   * the Cygan and Pilipczuk formula for the hafnian of matrix `mat`.
-   *
-   * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full hafnian is calculated.
-   *
-   * This function uses OpenMP (if available) to parallelize the reduction.
-   *
-   * @param mat vector representing the flattened matrix
-   * @param n size of the matrix
-   * @param X initial index of the partial sum
-   * @param chunksize length of the partial sum
-   * @return the partial sum for hafnian
-   */
-  template <typename T>
-  inline T do_chunk(std::vector<T> &mat, int n, unsigned long long int X, unsigned long long int chunksize) {
+/**
+ * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
+ * the Cygan and Pilipczuk formula for the hafnian of matrix `mat`.
+ *
+ * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full hafnian is calculated.
+ *
+ * This function uses OpenMP (if available) to parallelize the reduction.
+ *
+ * @param mat vector representing the flattened matrix
+ * @param n size of the matrix
+ * @param X initial index of the partial sum
+ * @param chunksize length of the partial sum
+ * @return the partial sum for hafnian
+ */
+template <typename T>
+inline T do_chunk(std::vector<T> &mat, int n, unsigned long long int X, unsigned long long int chunksize) {
     // This function calculates adds parts X to X+chunksize of Cygan and Pilipczuk formula for the
     // Hafnian of matrix mat
 
     T res = 0.0;
 
-#pragma omp parallel for
+    #pragma omp parallel for
     for (unsigned long long int x = X; x < X + chunksize; x++) {
-      T summand = 0.0;
+        T summand = 0.0;
 
-      Byte m = n / 2;
-      int i, j, k;
-      T factor, powfactor;
+        Byte m = n / 2;
+        int i, j, k;
+        T factor, powfactor;
 
-      char* dst = new char[m];
-      Byte* pos = new Byte[n];
-      dec2bin(dst, x, m);
-      Byte sum = find2(dst, m, pos);
-      delete [] dst;
+        char* dst = new char[m];
+        Byte* pos = new Byte[n];
+        dec2bin(dst, x, m);
+        Byte sum = find2(dst, m, pos);
+        delete [] dst;
 
-      std::vector<T> B(sum * sum, 0.0);
+        std::vector<T> B(sum * sum, 0.0);
 
-      for (i = 0; i < sum; i++) {
-	for (j = 0; j < sum; j++) {
-	  B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
-	}
-      }
-      delete [] pos;
+        for (i = 0; i < sum; i++) {
+            for (j = 0; j < sum; j++) {
+                B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
+            }
+        }
+        delete [] pos;
 
-      std::vector<T> traces(m, 0.0);
-      if (sum != 0) {
-	traces = powtrace(B, sum, m);
-      }
+        std::vector<T> traces(m, 0.0);
+        if (sum != 0) {
+            traces = powtrace(B, sum, m);
+        }
 
-      char cnt = 1;
-      Byte cntindex = 0;
+        char cnt = 1;
+        Byte cntindex = 0;
 
-      std::vector<T> comb(2 * (m + 1), 0.0);
-      comb[0] = 1.0;
+        std::vector<T> comb(2 * (m + 1), 0.0);
+        comb[0] = 1.0;
 
-      for (i = 1; i <= n / 2; i++) {
-	factor = traces[i - 1] / (2.0 * i);
-	powfactor = 1.0;
+        for (i = 1; i <= n / 2; i++) {
+            factor = traces[i - 1] / (2.0 * i);
+            powfactor = 1.0;
 
-	cnt = -cnt;
-	cntindex = (1 + cnt) / 2;
-	for (j = 0; j < n / 2 + 1; j++) {
-	  comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
-	}
-	for (j = 1; j <= (n / (2 * i)); j++) {
-	  powfactor = powfactor * factor / (1.0 * j);
-	  for (k = i * j + 1; k <= n / 2 + 1; k++) {
-	    comb[(m + 1) * (1 - cntindex) + k - 1] += comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
-	  }
-	}
-      }
-      if (((sum / 2) % 2) == (n / 2 % 2)) {
-	summand = comb[(m + 1) * (1 - cntindex) + n / 2];
-      }
-      else {
-	summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
-      }
-#pragma omp critical
-      res += summand;
+            cnt = -cnt;
+            cntindex = (1 + cnt) / 2;
+            for (j = 0; j < n / 2 + 1; j++) {
+                comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
+            }
+            for (j = 1; j <= (n / (2 * i)); j++) {
+                powfactor = powfactor * factor / (1.0 * j);
+                for (k = i * j + 1; k <= n / 2 + 1; k++) {
+                    comb[(m + 1) * (1 - cntindex) + k - 1] += comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
+                }
+            }
+        }
+        if (((sum / 2) % 2) == (n / 2 % 2)) {
+            summand = comb[(m + 1) * (1 - cntindex) + n / 2];
+        }
+        else {
+            summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
+        }
+        #pragma omp critical
+        res += summand;
     }
 
     return res;
-  }
+}
 
-  /**
-   * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
-   * the Cygan and Pilipczuk formula for the loop hafnian of matrix `mat`.
-   *
-   * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full loop hafnian is calculated.
-   *
-   * This function uses OpenMP (if available) to parallelize the reduction.
-   *
-   * @param mat vector representing the flattened matrix
-   * @param C contains the diagonal elements of matrix ``z``
-   * @param D the diagonal elements of matrix ``z``, with every consecutive pair
-   *      swapped (i.e., ``C[0]==D[1]``, ``C[1]==D[0]``, ``C[2]==D[3]``,
-   *      ``C[3]==D[2]``, etc.).
-   * @param n size of the matrix
-   * @param X initial index of the partial sum
-   * @param chunksize length of the partial sum
-   * @return the partial sum for the loop hafnian
-   */
-  template <typename T>
-  inline T do_chunk_loops(std::vector<T> &mat, std::vector<T> &C, std::vector<T> &D, int n, unsigned long long int X, unsigned long long int chunksize) {
+/**
+ * Calculates the partial sum \f$X,X+1,\dots,X+\text{chunksize}\f$ using
+ * the Cygan and Pilipczuk formula for the loop hafnian of matrix `mat`.
+ *
+ * Note that if `X=0` and `chunksize=pow(2.0, n/2)`, then the full loop hafnian is calculated.
+ *
+ * This function uses OpenMP (if available) to parallelize the reduction.
+ *
+ * @param mat vector representing the flattened matrix
+ * @param C contains the diagonal elements of matrix ``z``
+ * @param D the diagonal elements of matrix ``z``, with every consecutive pair
+ *      swapped (i.e., ``C[0]==D[1]``, ``C[1]==D[0]``, ``C[2]==D[3]``,
+ *      ``C[3]==D[2]``, etc.).
+ * @param n size of the matrix
+ * @param X initial index of the partial sum
+ * @param chunksize length of the partial sum
+ * @return the partial sum for the loop hafnian
+ */
+template <typename T>
+inline T do_chunk_loops(std::vector<T> &mat, std::vector<T> &C, std::vector<T> &D, int n, unsigned long long int X, unsigned long long int chunksize) {
 
     T res = 0.0;
 
-#pragma omp parallel for
+    #pragma omp parallel for
     for (unsigned long long int x = X * chunksize; x < (X + 1)*chunksize; x++) {
-      T summand = 0.0;
+        T summand = 0.0;
 
-      Byte m = n / 2;
-      int i, j, k;
-      T factor, powfactor;
+        Byte m = n / 2;
+        int i, j, k;
+        T factor, powfactor;
 
-      char* dst = new char[m];
-      Byte* pos = new Byte[n];
-      dec2bin(dst, x, m);
-      Byte sum = find2(dst, m, pos);
-      delete [] dst;
+        char* dst = new char[m];
+        Byte* pos = new Byte[n];
+        dec2bin(dst, x, m);
+        Byte sum = find2(dst, m, pos);
+        delete [] dst;
 
-      std::vector<T> B(sum * sum, 0.0), B_powtrace(sum * sum, 0.0);
-      std::vector<T> C1(sum, 0.0), D1(sum, 0.0);
+        std::vector<T> B(sum * sum, 0.0), B_powtrace(sum * sum, 0.0);
+        std::vector<T> C1(sum, 0.0), D1(sum, 0.0);
 
-      for (i = 0; i < sum; i++) {
-	for (j = 0; j < sum; j++) {
-	  B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
-	  B_powtrace[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
-	}
-	C1[i] = C[pos[i]];
-	D1[i] = D[pos[i]];
-      }
-      delete [] pos;
+        for (i = 0; i < sum; i++) {
+            for (j = 0; j < sum; j++) {
+                B[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
+                B_powtrace[i * sum + j] = mat[pos[i] * n + ((pos[j]) ^ 1)];
+            }
+            C1[i] = C[pos[i]];
+            D1[i] = D[pos[i]];
+        }
+        delete [] pos;
 
-      std::vector<T> traces(m, 0.0);
-      if (sum != 0) {
-	traces = powtrace(B, sum, m);
-      }
+        std::vector<T> traces(m, 0.0);
+        if (sum != 0) {
+            traces = powtrace(B, sum, m);
+        }
 
-      char cnt = 1;
-      Byte cntindex = 0;
+        char cnt = 1;
+        Byte cntindex = 0;
 
-      std::vector<T> comb(2 * (m + 1), 0.0);
-      comb[0] = 1.0;
+        std::vector<T> comb(2 * (m + 1), 0.0);
+        comb[0] = 1.0;
 
-      for (i = 1; i <= n / 2; i++) {
-	factor = traces[i - 1] / (2.0 * i);
-	T tmpn = 0.0;
+        for (i = 1; i <= n / 2; i++) {
+            factor = traces[i - 1] / (2.0 * i);
+            T tmpn = 0.0;
 
-	for (int i = 0; i < sum; i++) {
-	  tmpn += C1[i] * D1[i];
-	}
+            for (int i = 0; i < sum; i++) {
+                tmpn += C1[i] * D1[i];
+            }
 
-	factor += 0.5 * tmpn;
-	std::vector<T> tmp_c1(sum, 0.0);
+            factor += 0.5 * tmpn;
+            std::vector<T> tmp_c1(sum, 0.0);
 
-	T tmp = 0.0;
+            T tmp = 0.0;
 
-	for (int i = 0; i < sum; i++) {
-	  tmp = 0.0;
+            for (int i = 0; i < sum; i++) {
+                tmp = 0.0;
 
-	  for (int j = 0; j < sum; j++) {
-	    tmp += C1[j] * B[j * sum + i];
-	  }
+                for (int j = 0; j < sum; j++) {
+                    tmp += C1[j] * B[j * sum + i];
+                }
 
-	  tmp_c1[i] = tmp;
-	}
+                tmp_c1[i] = tmp;
+            }
 
-	for (int i = 0; i < sum; i++) {
-	  C1[i] = tmp_c1[i];
-	}
+            for (int i = 0; i < sum; i++) {
+                C1[i] = tmp_c1[i];
+            }
 
-	powfactor = 1.0;
+            powfactor = 1.0;
 
-	cnt = -cnt;
-	cntindex = (1 + cnt) / 2;
-	for (j = 0; j < n / 2 + 1; j++) {
-	  comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
-	}
+            cnt = -cnt;
+            cntindex = (1 + cnt) / 2;
+            for (j = 0; j < n / 2 + 1; j++) {
+                comb[(m + 1) * (1 - cntindex) + j] = comb[(m + 1) * cntindex + j];
+            }
 
-	for (j = 1; j <= (n / (2 * i)); j++) {
-	  powfactor = powfactor * factor / (1.0 * j);
-	  for (k = i * j + 1; k <= n / 2 + 1; k++) {
-	    comb[(m + 1) * (1 - cntindex) + k - 1] = comb[(m + 1) * (1 - cntindex) + k - 1] + comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
-	  }
-	}
-      }
+            for (j = 1; j <= (n / (2 * i)); j++) {
+                powfactor = powfactor * factor / (1.0 * j);
+                for (k = i * j + 1; k <= n / 2 + 1; k++) {
+                    comb[(m + 1) * (1 - cntindex) + k - 1] = comb[(m + 1) * (1 - cntindex) + k - 1] + comb[(m + 1) * cntindex + k - i * j - 1] * powfactor;
+                }
+            }
+        }
 
-      if (((sum / 2) % 2) == (n / 2 % 2)) {
-	summand = comb[(m + 1) * (1 - cntindex) + n / 2];
-      }
-      else {
-	summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
-      }
-#pragma omp critical
-      res += summand;
+        if (((sum / 2) % 2) == (n / 2 % 2)) {
+            summand = comb[(m + 1) * (1 - cntindex) + n / 2];
+        }
+        else {
+            summand = -comb[(m + 1) * (1 - cntindex) + n / 2];
+        }
+        #pragma omp critical
+        res += summand;
     }
 
     return res;
-  }
+}
 
 
-  /**
-   * Returns the hafnian of a matrix using the algorithm described in
-   * *A faster hafnian formula for complex matrices and its benchmarking
-   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-   *
-   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-   *       row-ordered symmetric matrix.
-   * @return hafnian of the input matrix
-   */
-  template <typename T>
-  inline T hafnian(std::vector<T> &mat) {
+/**
+ * Returns the hafnian of a matrix using the algorithm described in
+ * *A faster hafnian formula for complex matrices and its benchmarking
+ * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+ *
+ * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+ *       row-ordered symmetric matrix.
+ * @return hafnian of the input matrix
+ */
+template <typename T>
+inline T hafnian(std::vector<T> &mat) {
     int n = std::sqrt(static_cast<double>(mat.size()));
     assert(n % 2 == 0);
 
@@ -253,20 +253,20 @@ namespace libwalrus {
     T haf;
     haf = do_chunk(mat, n, rank, chunksize);
     return  haf;
-  }
+}
 
 
-  /**
-   * Returns the loop hafnian of a matrix using the algorithm described in
-   * *A faster hafnian formula for complex matrices and its benchmarking
-   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-   *
-   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-   *       row-ordered symmetric matrix.
-   * @return hafnian of the input matrix
-   */
-  template <typename T>
-  inline T loop_hafnian(std::vector<T> &mat) {
+/**
+ * Returns the loop hafnian of a matrix using the algorithm described in
+ * *A faster hafnian formula for complex matrices and its benchmarking
+ * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+ *
+ * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+ *       row-ordered symmetric matrix.
+ * @return hafnian of the input matrix
+ */
+template <typename T>
+inline T loop_hafnian(std::vector<T> &mat) {
     int n = std::sqrt(static_cast<double>(mat.size()));
     assert(n % 2 == 0);
 
@@ -282,153 +282,153 @@ namespace libwalrus {
     unsigned long long int rank = 0;
 
     for (int i = 0; i < n; i++) {
-      D[i] = mat[i * n + i];
+        D[i] = mat[i * n + i];
     }
 
     for (int i = 0; i < n; i += 2) {
-      C[i] = D[i + 1];
-      C[i + 1] = D[i];
+        C[i] = D[i + 1];
+        C[i + 1] = D[i];
     }
 
     T haf;
     haf = do_chunk_loops(mat, C, D, n, rank, chunksize);
     return  haf;
-  }
+}
 
 
-  /**
-   * Returns the hafnian of a matrix using the algorithm described in
-   * *A faster hafnian formula for complex matrices and its benchmarking
-   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-   *
-   * This is a wrapper around the templated function hafnian() for Python
-   * integration. It accepts and returns complex double numeric types, and
-   * returns sensible values for empty and non-even matrices.
-   *
-   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-   *       row-ordered symmetric matrix.
-   * @return hafnian of the input matrix
-   */
-  std::complex<double> hafnian_eigen(std::vector<std::complex<double>> &mat) {
+/**
+ * Returns the hafnian of a matrix using the algorithm described in
+ * *A faster hafnian formula for complex matrices and its benchmarking
+ * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+ *
+ * This is a wrapper around the templated function hafnian() for Python
+ * integration. It accepts and returns complex double numeric types, and
+ * returns sensible values for empty and non-even matrices.
+ *
+ * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+ *       row-ordered symmetric matrix.
+ * @return hafnian of the input matrix
+ */
+std::complex<double> hafnian_eigen(std::vector<std::complex<double>> &mat) {
     std::vector<std::complex<double>> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     std::complex<double> haf;
 
     if (n == 0)
-      haf = std::complex<double>(1.0, 0.0);
+        haf = std::complex<double>(1.0, 0.0);
     else if (n % 2 != 0)
-      haf = std::complex<double>(0.0, 0.0);
+        haf = std::complex<double>(0.0, 0.0);
     else
-      haf = hafnian(matq);
+        haf = hafnian(matq);
 
     return haf;
-  }
+}
 
 
-  /**
-   * Returns the hafnian of a matrix using the algorithm described in
-   * *A faster hafnian formula for complex matrices and its benchmarking
-   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-   *
-   * This is a wrapper around the templated function hafnian() for Python
-   * integration. It accepts and returns double numeric types, and
-   * returns sensible values for empty and non-even matrices.
-   *
-   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-   *       row-ordered symmetric matrix.
-   * @return hafnian of the input matrix
-   */
-  double hafnian_eigen(std::vector<double> &mat) {
+/**
+ * Returns the hafnian of a matrix using the algorithm described in
+ * *A faster hafnian formula for complex matrices and its benchmarking
+ * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+ *
+ * This is a wrapper around the templated function hafnian() for Python
+ * integration. It accepts and returns double numeric types, and
+ * returns sensible values for empty and non-even matrices.
+ *
+ * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+ *       row-ordered symmetric matrix.
+ * @return hafnian of the input matrix
+ */
+double hafnian_eigen(std::vector<double> &mat) {
     std::vector<double> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     double haf;
 
     if (n == 0)
-      haf = 1.0;
+        haf = 1.0;
     else if (n % 2 != 0)
-      haf = 0.0;
+        haf = 0.0;
     else
-      haf = static_cast<double>(hafnian(matq));
+        haf = static_cast<double>(hafnian(matq));
 
     return haf;
-  }
+}
 
 
-  /**
-   * Returns the loop hafnian of a matrix using the algorithm described in
-   * *A faster hafnian formula for complex matrices and its benchmarking
-   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-   *
-   * This is a wrapper around the templated function libwalrus::loop_hafnian() for Python
-   * integration. It accepts and returns complex double numeric types, and
-   * returns sensible values for empty and non-even matrices.
-   *
-   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-   *       row-ordered symmetric matrix.
-   * @return loop hafnian of the input matrix
-   */
-  std::complex<double> loop_hafnian_eigen(std::vector<std::complex<double>> &mat) {
+/**
+ * Returns the loop hafnian of a matrix using the algorithm described in
+ * *A faster hafnian formula for complex matrices and its benchmarking
+ * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+ *
+ * This is a wrapper around the templated function libwalrus::loop_hafnian() for Python
+ * integration. It accepts and returns complex double numeric types, and
+ * returns sensible values for empty and non-even matrices.
+ *
+ * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+ *       row-ordered symmetric matrix.
+ * @return loop hafnian of the input matrix
+ */
+std::complex<double> loop_hafnian_eigen(std::vector<std::complex<double>> &mat) {
     std::vector<std::complex<double>> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     std::complex<double> haf;
     std::vector<std::complex<double>> matq2((n + 1) * (n + 1), std::complex<double>(0.0, 0.0));
 
     if (n == 0)
-      haf = std::complex<double>(1.0, 0.0);
+        haf = std::complex<double>(1.0, 0.0);
     else if (n % 2 != 0) {
-      for (int i = 0; i < n; i++) {
-	for (int j = 0; j < n; j++) {
-	  matq2[i * (n + 1) + j] = matq[i * n + j];
-	}
-      }
-      matq2[(n + 1) * (n + 1) - 1] = std::complex<double>(1.0, 0.0);
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                matq2[i * (n + 1) + j] = matq[i * n + j];
+            }
+        }
+        matq2[(n + 1) * (n + 1) - 1] = std::complex<double>(1.0, 0.0);
 
 
-      haf = loop_hafnian(matq2);
+        haf = loop_hafnian(matq2);
     }
     else
-      haf = loop_hafnian(matq);
+        haf = loop_hafnian(matq);
 
     return haf;
-  }
+}
 
 
-  /**
-   * Returns the loop hafnian of a matrix using the algorithm described in
-   * *A faster hafnian formula for complex matrices and its benchmarking
-   * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
-   *
-   * This is a wrapper around the templated function loop_hafnian() for Python
-   * integration. It accepts and returns double numeric types, and
-   * returns sensible values for empty and non-even matrices.
-   *
-   * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
-   *       row-ordered symmetric matrix.
-   * @return loop hafnian of the input matrix
-   */
-  double loop_hafnian_eigen(std::vector<double> &mat) {
+/**
+ * Returns the loop hafnian of a matrix using the algorithm described in
+ * *A faster hafnian formula for complex matrices and its benchmarking
+ * on the Titan supercomputer*, [arxiv:1805.12498](https://arxiv.org/abs/1805.12498>).
+ *
+ * This is a wrapper around the templated function loop_hafnian() for Python
+ * integration. It accepts and returns double numeric types, and
+ * returns sensible values for empty and non-even matrices.
+ *
+ * @param mat a flattened vector of size \f$n^2\f$, representing an \f$n\times n\f$
+ *       row-ordered symmetric matrix.
+ * @return loop hafnian of the input matrix
+ */
+double loop_hafnian_eigen(std::vector<double> &mat) {
     std::vector<double> matq(mat.begin(), mat.end());
     int n = std::sqrt(static_cast<double>(mat.size()));
     double haf;
     std::vector<double> matq2((n + 1) * (n + 1), 0.0);
 
     if (n == 0)
-      haf = 1.0;
+        haf = 1.0;
     else if (n % 2 != 0) {
-      for (int i = 0; i < n; i++) {
-	for (int j = 0; j < n; j++) {
-	  matq2[i * (n + 1) + j] = mat[i * n + j];
-	}
-      }
-      matq2[(n + 1) * (n + 1) - 1] = 1.0;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                matq2[i * (n + 1) + j] = mat[i * n + j];
+            }
+        }
+        matq2[(n + 1) * (n + 1) - 1] = 1.0;
 
 
-      haf = loop_hafnian(matq2);
+        haf = loop_hafnian(matq2);
     }
     else
-      haf = static_cast<double>(loop_hafnian(matq));
+        haf = static_cast<double>(loop_hafnian(matq));
 
     return haf;
-  }
+}
 
 }

--- a/include/powtrace.hpp
+++ b/include/powtrace.hpp
@@ -1,0 +1,427 @@
+#pragma once
+
+namespace libwalrus {
+
+// definition of enable_if_t for std=c++11
+// already defined in std=c++14
+template <bool B, class T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+// definition of is_complex for checking if scalar type is complex
+template <class T> struct is_complex : std::false_type {};
+template <class T> struct is_complex<std::complex<T>> : std::true_type {};
+
+/**
+ * Auxiliary function for Labudde algorithm. Returns
+ * Euclidean norm squared of the complex vector.
+ *
+ * @param vec complex vector
+ *
+ * @return Euclidean norm squared
+ */
+template <typename T, enable_if_t<is_complex<T>{}> * = nullptr>
+T norm_sqr(const std::vector<T> &vec) {
+  T ns = static_cast<T>(0);
+  size_t vec_size = vec.size();
+  for (size_t i = 0; i < vec_size; i++) {
+    ns += vec[i] * std::conj(vec[i]);
+  }
+  return ns;
+}
+
+/**
+ * Auxiliary function for Labudde algorithm. Returns
+ * Euclidean norm squared of the non-complex vector.
+ *
+ * @param vec non-complex vector
+ *
+ * @return Euclidean norm squared
+ */
+template <typename T, enable_if_t<!is_complex<T>{}> * = nullptr>
+T norm_sqr(const std::vector<T> &vec) {
+  T ns = static_cast<T>(0);
+  size_t vec_size = vec.size();
+  for (size_t i = 0; i < vec_size; i++) {
+    ns += vec[i] * vec[i];
+  }
+  return ns;
+}
+/**
+ * Auxiliary function for Labudde algorithm. Returns
+ * conjugate of complex variable or variable if not complex.
+ * Useful for functions agnostic to the scalar type.
+ * Allows us to reuse code for complex and non-complex types.
+ *
+ * @param val complex scalar
+ *
+ * @return the complex conjugate
+ */
+template <typename T, enable_if_t<is_complex<T>{}> * = nullptr>
+inline T conjugate(T val) {
+  return std::conj(val);
+}
+
+/**
+ * Auxiliary function for Labudde algorithm. Returns
+ * conjugate of complex variable or variable if not complex.
+ * Useful for functions agnostic to the scalar type.
+ * Allows us to reuse code for complex and non-complex types.
+ *
+ * @param val non-complex scalar
+ *
+ * @return the non-complex scalar
+ */
+template <typename T, enable_if_t<!is_complex<T>{}> * = nullptr>
+inline T conjugate(T val) {
+  return val;
+}
+
+/**
+ * Auxiliary function for Labudde algorithm. Returns
+ * Euclidean norm of the complex vector.
+ *
+ * @param vec complex vector
+ *
+ * @return Euclidean norm
+ */
+template <typename T, enable_if_t<is_complex<T>{}> * = nullptr>
+T norm(const std::vector<T> &vec) {
+  return sqrt(std::real(norm_sqr(vec)));
+}
+
+/**
+ * Auxiliary function for Labudde algorithm. Returns
+ * Euclidean norm of the non-complex vector.
+ *
+ * @param vec non-complex vector
+ *
+ * @return Euclidean norm
+ */
+template <typename T, enable_if_t<!is_complex<T>{}> * = nullptr>
+T norm(const std::vector<T> &vec) {
+  return sqrt(norm_sqr(vec));
+}
+
+/**
+ * Auxiliary function for Labudde algorithm.
+ * See pg 10 of for definition of beta
+ * [arXiv:1104.3769](https://arxiv.org/abs/1104.3769v1).
+ *
+ * @param H upper-Hessenberg matrix
+ * @param i row
+ * @param size size of matrix
+ *
+ * @return element of the lower-diagonal of matrix H
+ */
+template <typename T>
+inline T beta(const std::vector<T> &H, size_t i, size_t size) {
+  return H[(i - 1) * size + i - 2];
+}
+
+/**
+ * Auxiliary function for Labudde algorithm.
+ * See pg 10 of for definition of alpha
+ * [arXiv:1104.3769](https://arxiv.org/abs/1104.3769v1).
+ *
+ * @param H upper-Hessenberg matrix
+ * @param i row
+ * @param size size of matrix
+ *
+ * @return element of the central-diagonal of matrix H
+ */
+template <typename T>
+inline T alpha(const std::vector<T> &H, size_t i, size_t size) {
+  return H[(i - 1) * size + i - 1];
+}
+
+/**
+ * Auxiliary function for Labudde algorithm.
+ * See pg 10 of for definition of hij
+ * [arXiv:1104.3769](https://arxiv.org/abs/1104.3769v1).
+ *
+ * @param H upper-Hessenberg matrix
+ * @param i row
+ * @param j column
+ * @param size size of matrix
+ *
+ * @return element of upper triangle of matrix H
+ */
+template <typename T>
+inline T hij(const std::vector<T> &H, size_t i, size_t j, size_t size) {
+  return H[(i - 1) * size + j - 1];
+}
+
+/**
+ * Auxiliary function for Labudde algorithm.
+ * The paper uses indices that start counting at 1
+ * so this function lowers them to start counting at 0.
+ *
+ * @param H upper-Hessenberg matrix
+ * @param i row
+ * @param j column
+ * @param size size of matrix
+ *
+ * @return element of upper triangle of matrix H
+ */
+inline size_t mlo(size_t i, size_t j, size_t size) {
+  return (i - 1) * size + j - 1;
+}
+
+/**
+ * Compute characteristic polynomial using the LaBudde algorithm.
+ * See [arXiv:1104.3769](https://arxiv.org/abs/1104.3769v1).
+ * If the matrix is n by n but you only want coefficients k < n
+ * set k below n. If you want all coefficients, set k = n.
+ *
+ * @param H matrix in Hessenberg form (RowMajor)
+ * @param n size of matrix
+ * @param k compute coefficients up to k (k must be <= n)
+ * @return char-poly coeffs + auxiliary data (see comment in function)
+ *
+ */
+template <typename T>
+std::vector<T> charpoly_from_labudde(const std::vector<T> &H, size_t n,
+                                     size_t k)
+{
+ // the matrix c holds not just the polynomial coefficients, but also auxiliary
+ // data. To retrieve the characteristic polynomial coeffients from the matrix c, use
+ // this map for characteristic polynomial coefficient c_j:
+ // if j = 0, c_0 -> 1
+ // if j > 0, c_j -> c[(n - 1) * n + j - 1]
+  std::vector<T> c(n * n);
+  c[mlo(1, 1, n)] = -alpha(H, 1, n);
+  c[mlo(2, 1, n)] = c[mlo(1, 1, n)] - alpha(H, 2, n);
+  c[mlo(2, 2, n)] =
+      alpha(H, 1, n) * alpha(H, 2, n) - hij(H, 1, 2, n) * beta(H, 2, n);
+
+  for (size_t i = 3; i <= k; i++) {
+    c[mlo(i, 1, n)] = c[mlo(i - 1, 1, n)] - alpha(H, i, n);
+
+    for (size_t j = 2; j <= i - 1; j++) {
+      T sum = 0.;
+      T beta_prod;
+      for (size_t m = 1; m <= j - 2; m++) {
+        beta_prod = 1.;
+        for (size_t bm = i; bm >= i - m + 1; bm--) {
+          beta_prod *= beta(H, bm, n);
+        }
+        sum +=
+            hij(H, i - m, i, n) * beta_prod * c[mlo(i - m - 1, j - m - 1, n)];
+      }
+      beta_prod = 1.;
+      for (size_t bm = i; bm >= i - j + 2; bm--) {
+        beta_prod *= beta(H, bm, n);
+      }
+      c[mlo(i, j, n)] = c[mlo(i - 1, j, n)] -
+                        alpha(H, i, n) * c[mlo(i - 1, j - 1, n)] - sum -
+                        hij(H, i - j + 1, i, n) * beta_prod;
+    }
+    T sum = 0.;
+    T beta_prod;
+    for (size_t m = 1; m <= i - 2; m++) {
+      beta_prod = 1.;
+      for (size_t bm = i; bm >= i - m + 1; bm--) {
+        beta_prod *= beta(H, bm, n);
+      }
+      sum += hij(H, i - m, i, n) * beta_prod * c[mlo(i - m - 1, i - m - 1, n)];
+    }
+
+    beta_prod = 1.;
+    for (size_t bm = i; bm >= 2; bm--) {
+      beta_prod *= beta(H, bm, n);
+    }
+    c[mlo(i, i, n)] = -alpha(H, i, n) * c[mlo(i - 1, i - 1, n)] - sum -
+                      hij(H, 1, i, n) * beta_prod;
+  }
+
+  for (size_t i = k + 1; i <= n; i++) {
+    c[mlo(i, 1, n)] = c[mlo(i - 1, 1, n)] - alpha(H, i, n);
+    if (k >= 2) {
+      for (size_t j = 2; j <= k; j++) {
+        T sum = 0.;
+        T beta_prod;
+        for (size_t m = 1; m <= j - 2; m++) {
+          beta_prod = 1.;
+          for (size_t bm = i; bm >= i - m + 1; bm--) {
+            beta_prod *= beta(H, bm, n);
+          }
+          sum +=
+              hij(H, i - m, i, n) * beta_prod * c[mlo(i - m - 1, j - m - 1, n)];
+        }
+        beta_prod = 1.;
+        for (size_t bm = i; bm >= i - j + 2; bm--) {
+          beta_prod *= beta(H, bm, n);
+        }
+
+        c[mlo(i, j, n)] = c[mlo(i - 1, j, n)] -
+                          alpha(H, i, n) * c[mlo(i - 1, j - 1, n)] - sum -
+                          hij(H, i - j + 1, i, n) * beta_prod;
+      }
+    }
+  }
+  return c;
+}
+
+/**
+ * Compute reflection vector for householder transformation on
+ * general complex matrices.
+ * See Introduction to Numerical Analysis-Springer New York (2002)
+ * (3rd Edition) by J. Stoer and R. Bulirsch Section 6.5.1
+ *
+ * @param size
+ * @param matrix
+ * @param sizeH size of reflection vector
+ * @param reflect_vector householder reflection vector
+ *
+ */
+template <typename T>
+std::vector<T> get_reflection_vector(std::vector<T> &matrix, size_t size,
+                                     size_t k) {
+  size_t sizeH = size - k;
+  std::vector<T> reflect_vector(sizeH);
+  size_t order = size - sizeH;
+  size_t offset = order - 1;
+
+  std::vector<T> matrix_column(sizeH);
+  for (size_t i = 0; i < sizeH; i++) {
+    matrix_column[i] = matrix[(i + order) * size + offset];
+  }
+
+  T sigma = norm(matrix_column);
+  if (matrix_column[0] != 0.)
+    sigma *= matrix_column[0] / std::abs(matrix_column[0]);
+
+  for (size_t i = 0; i < sizeH; i++) {
+    reflect_vector[i] = matrix_column[i];
+  }
+  reflect_vector[0] += sigma;
+  return reflect_vector;
+}
+
+/**
+ * Apply householder transformation on a matrix A
+ * See  Matrix Computations by Golub and Van Loan
+ * (4th Edition) Sections 5.1.4 and 7.4.2
+ *
+ * @param A matrix to apply householder on
+ * @param v reflection vector
+ * @param size_A size of matrix A
+ * @param k start of submatrix
+ *
+ * @return coefficients
+ */
+template <typename T>
+void apply_householder(std::vector<T> &A, std::vector<T> &v, size_t size_A,
+                       size_t k) {
+  size_t sizeH = v.size();
+
+  auto norm_v_sqr = norm_sqr(v);
+  if (norm_v_sqr == 0.)
+    return;
+
+  std::vector<T> vHA(size_A - k + 1, 0.);
+  std::vector<T> Av(size_A, 0.);
+  for (size_t j = 0; j < size_A - k + 1; j++) {
+    for (size_t l = 0; l < sizeH; l++) {
+      vHA[j] += conjugate(v[l]) * A[(k + l) * size_A + k - 1 + j];
+    }
+  }
+  for (size_t i = 0; i < sizeH; i++) {
+    for (size_t j = 0; j < size_A - k + 1; j++) {
+      A[(k + i) * size_A + k - 1 + j] -= 2. * v[i] * vHA[j] / norm_v_sqr;
+    }
+  }
+  for (size_t i = 0; i < size_A; i++) {
+    for (size_t l = 0; l < sizeH; l++) {
+      Av[i] += A[(i)*size_A + k + l] * v[l];
+    }
+  }
+  for (size_t i = 0; i < size_A; i++) {
+    for (size_t j = 0; j < sizeH; j++) {
+      A[(i)*size_A + k + j] -= 2. * Av[i] * conjugate(v[j]) / norm_v_sqr;
+    }
+  }
+}
+
+/**
+ * Reduce the matrix to upper hessenberg form
+ * without Lapack. This function only accepts
+ * RowOrder matrices right now.
+ *
+ * @param matrix matrix to reduce
+ * @param size size of matrix
+ *
+ */
+template <typename T>
+void reduce_matrix_to_hessenberg(std::vector<T> &matrix, size_t size) {
+  for (size_t i = 1; i < size - 1; i++) {
+    std::vector<T> &&reflect_vector = get_reflection_vector(matrix, size, i);
+    apply_householder(matrix, reflect_vector, size, i);
+  }
+}
+
+
+/**
+ * Compute the trace of \f$ A^{p}\f$, where p is an integer
+ * and A is a square matrix using its characteristic
+ * polynomial. In the case that the power p is above
+ * the size of the matrix we can use an optimization
+ * described in Appendix B of
+ * [arxiv:1805.12498](https://arxiv.org/pdf/1104.3769v1.pdf)
+ *
+ * @param c the characteristic polynomial coefficients
+ * @param n size of matrix
+ * @param pow exponent p
+ *
+ * @return coefficients
+ */
+template <typename T>
+std::vector<T> powtrace_from_charpoly(const std::vector<T> &c, size_t n,
+                                      size_t pow) {
+  if (pow == 0)
+    return std::vector<T>({static_cast<T>(n)});
+
+  std::vector<T> traces(pow);
+  traces[0] = -c[(n - 1) * n];
+
+  // Calculate traces using the LeVerrier
+  // recursion relation
+  for (size_t k = 2; k <= pow; k++) {
+    traces[k - 1] = -static_cast<T>(k) * c[(n - 1) * n + k - 1];
+    for (size_t j = k - 1; j >= 1; j--) {
+      traces[k - 1] -= c[(n - 1) * n + k - j - 1] * traces[j - 1];
+    }
+  }
+
+  // Appendix B optimization
+  if (pow > n) {
+    for (size_t l = 1; l <= pow - n; l++) {
+      traces[n + l - 1] = 0.;
+      for (size_t j = 1; j <= n; j++) {
+        traces[l + n - 1] -= traces[n - j + l - 1] * c[(n - 1) * n + j - 1];
+      }
+    }
+  }
+  return traces;
+}
+
+/**
+ * Given a complex matrix \f$z\f$ of dimensions \f$n\times n\f$, it calculates
+ * \f$Tr(z^j)~\forall~1\leq j\leq l\f$.
+ *
+ * @param z a flattened complex vector of size \f$n^2\f$, representing an
+ *       \f$n\times n\f$ row-ordered matrix.
+ * @param n size of the matrix `z`.
+ * @param l maximum matrix power when calculating the power trace.
+ * @return a vector containing the power traces of matrix `z` to power
+ *       \f$1\leq j \leq l\f$.
+ */
+template <typename T>
+std::vector<T> powtrace(std::vector<T> &z, size_t n, size_t l) {
+  std::vector<T> z_copy = z;
+  reduce_matrix_to_hessenberg(z_copy, n);
+  std::vector<T> && coeffs_labudde = charpoly_from_labudde(z_copy, n, n);
+  return powtrace_from_charpoly(coeffs_labudde, n, l);
+}
+
+} // namespace libwalrus

--- a/include/powtrace.hpp
+++ b/include/powtrace.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <type_traits>
+
 namespace libwalrus {
 
 // definition of enable_if_t for std=c++11

--- a/include/powtrace.hpp
+++ b/include/powtrace.hpp
@@ -163,7 +163,7 @@ inline T hij(const std::vector<T> &H, size_t i, size_t j, size_t size) {
  * @param j column
  * @param size size of matrix
  *
- * @return element of upper triangle of matrix H
+ * @return linear matrix index lowered by 1
  */
 inline size_t mlo(size_t i, size_t j, size_t size) {
   return (i - 1) * size + j - 1;

--- a/include/powtrace.hpp
+++ b/include/powtrace.hpp
@@ -290,7 +290,7 @@ std::vector<T> get_reflection_vector(std::vector<T> &matrix, size_t size,
   }
 
   T sigma = norm(matrix_column);
-  if (matrix_column[0] != 0.)
+  if (matrix_column[0] != static_cast<T> (0.))
     sigma *= matrix_column[0] / std::abs(matrix_column[0]);
 
   for (size_t i = 0; i < sizeH; i++) {
@@ -318,7 +318,7 @@ void apply_householder(std::vector<T> &A, std::vector<T> &v, size_t size_A,
   size_t sizeH = v.size();
 
   auto norm_v_sqr = norm_sqr(v);
-  if (norm_v_sqr == 0.)
+  if (norm_v_sqr == static_cast<T>(0.))
     return;
 
   std::vector<T> vHA(size_A - k + 1, 0.);
@@ -330,7 +330,7 @@ void apply_householder(std::vector<T> &A, std::vector<T> &v, size_t size_A,
   }
   for (size_t i = 0; i < sizeH; i++) {
     for (size_t j = 0; j < size_A - k + 1; j++) {
-      A[(k + i) * size_A + k - 1 + j] -= 2. * v[i] * vHA[j] / norm_v_sqr;
+      A[(k + i) * size_A + k - 1 + j] -= static_cast<T>(2.) * v[i] * vHA[j] / norm_v_sqr;
     }
   }
   for (size_t i = 0; i < size_A; i++) {
@@ -340,7 +340,7 @@ void apply_householder(std::vector<T> &A, std::vector<T> &v, size_t size_A,
   }
   for (size_t i = 0; i < size_A; i++) {
     for (size_t j = 0; j < sizeH; j++) {
-      A[(i)*size_A + k + j] -= 2. * Av[i] * conjugate(v[j]) / norm_v_sqr;
+      A[(i)*size_A + k + j] -= static_cast<T>(2.) * Av[i] * conjugate(v[j]) / norm_v_sqr;
     }
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ if BUILD_EXT:
     if platform.system() == 'Windows':
         USE_OPENMP = False
         cflags_default = "-static -O3 -Wall -fPIC"
-        extra_link_args_CPP = ["-std=c++11 -static", "-static-libgfortran", "-static-libgcc"]
+        extra_link_args_CPP = ["-std=c++14 -static", "-static-libgfortran", "-static-libgcc"]
     elif platform.system() == 'Darwin':
         cflags_default = "-O3 -Wall -fPIC -shared -Xpreprocessor -fopenmp -lomp -mmacosx-version-min=10.9"
         libraries += ["omp"]
@@ -123,7 +123,7 @@ if BUILD_EXT:
                 library_dirs=['/usr/lib', '/usr/local/lib'] + LD_LIBRARY_PATH,
                 libraries=libraries,
                 language="c++",
-                extra_compile_args=["-std=c++11"] + CFLAGS,
+                extra_compile_args=["-std=c++14"] + CFLAGS,
                 extra_link_args=extra_link_args_CPP)
     ], compile_time_env={'_OPENMP': USE_OPENMP, 'LAPACKE': USE_LAPACK})
 else:

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ if BUILD_EXT:
                 library_dirs=['/usr/lib', '/usr/local/lib'] + LD_LIBRARY_PATH,
                 libraries=libraries,
                 language="c++",
-                extra_compile_args=["-std=c++14"] + CFLAGS,
+                extra_compile_args=["-std=c++11"] + CFLAGS,
                 extra_link_args=extra_link_args_CPP)
     ], compile_time_env={'_OPENMP': USE_OPENMP, 'LAPACKE': USE_LAPACK})
 else:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 EIGEN_INCLUDE_DIR ?= /usr/include/eigen3
 CC = g++
-CFLAGS = -std=c++11 -O3 -g -Wall -fopenmp -fPIC -I/usr/include \
+CFLAGS = -std=c++14 -O3 -g -Wall -fopenmp -fPIC -I/usr/include \
 	-I../include -I$(EIGEN_INCLUDE_DIR) -I$(GOOGLETEST_DIR)/include \
 	-march=native
 

--- a/thewalrus/libwalrus.pyx
+++ b/thewalrus/libwalrus.pyx
@@ -129,6 +129,9 @@ cdef extern from "../include/libwalrus.hpp" namespace "libwalrus":
     double hafnian_recursive_quad(vector[double] &mat)
     double complex hafnian_recursive_quad(vector[double complex] &mat)
 
+    double loop_hafnian_quad(vector[double] &mat)
+    double complex loop_hafnian_quad(vector[double complex] &mat)
+
     double hafnian_rpt_quad(vector[double] &mat, vector[int] &nud)
     double complex hafnian_rpt_quad(vector[double complex] &mat, vector[int] &nu)
 
@@ -351,6 +354,8 @@ def haf_complex(double complex[:, :] A, bint loop=False, bint recursive=True, qu
 
     # Exposes a c function to python
     if loop:
+        if quad:
+            return loop_hafnian_quad(mat)
         return loop_hafnian(mat)
 
     if recursive:
@@ -388,6 +393,8 @@ def haf_real(double[:, :] A, bint loop=False, bint recursive=True, quad=True, bi
 
     # Exposes a c function to python
     if loop:
+        if quad:
+            return loop_hafnian_quad(mat)
         return loop_hafnian(mat)
 
     if approx:


### PR DESCRIPTION
**Context:**

The power trace computation in eigenvalue_hafnian uses Eigen's diagonalization routine. This can be made potentially faster by computing the characteristic polynomial first. Eigen also doesn't support long double.

**Description of the Change:**

Use the Labudde algorithm and optimization in Appendix B of Nico's paper to compute the power trace faster than Eigen for most sizes. Labudde is faster and more stable than Fadeev-Leverrier, see more here: https://arxiv.org/abs/1104.3769. With this change it will be easier to optimize the eigenvalue hafnian algorithm even further if needed.

**Benefits:**

Speed-up
Removes Eigen from the hafnian calculation
Long double support

**Possible Drawbacks:**
- None

**Related GitHub Issues:**
Fadeev-Leverrier algorithm for power traces #36