### PR TITLE
Support C++14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ cache:
 matrix:
   fast_finish: false
 
+image: Visual Studio 2017
 
 install:
   - ps: wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip -outfile eigen3.zip

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -14,7 +14,7 @@
 EIGEN_INCLUDE_DIR?=/usr/include/eigen3
 
 CC=g++
-CFLAGS=-std=c++11 -O3 -Wall -I/usr/include -I../include -I$(EIGEN_INCLUDE_DIR) -fopenmp -march=native
+CFLAGS=-std=c++14 -O3 -Wall -I/usr/include -I../include -I$(EIGEN_INCLUDE_DIR) -fopenmp -march=native
 LFLAGS=-L/usr/lib -lm -fopenmp
 
 all: example-cpp

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ if BUILD_EXT:
     if platform.system() == 'Windows':
         USE_OPENMP = False
         cflags_default = "-static -O3 -Wall -fPIC"
-        extra_link_args_CPP = ["-std=c++11 -static", "-static-libgfortran", "-static-libgcc"]
+        extra_link_args_CPP = ["-std=c++14 -static", "-static-libgfortran", "-static-libgcc"]
     elif platform.system() == 'Darwin':
         cflags_default = "-O3 -Wall -fPIC -shared -Xpreprocessor -fopenmp -lomp -mmacosx-version-min=10.9"
         libraries += ["omp"]
@@ -123,7 +123,7 @@ if BUILD_EXT:
                 library_dirs=['/usr/lib', '/usr/local/lib'] + LD_LIBRARY_PATH,
                 libraries=libraries,
                 language="c++",
-                extra_compile_args=["-std=c++11"] + CFLAGS,
+                extra_compile_args=["-std=c++14"] + CFLAGS,
                 extra_link_args=extra_link_args_CPP)
     ], compile_time_env={'_OPENMP': USE_OPENMP, 'LAPACKE': USE_LAPACK})
 else:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 EIGEN_INCLUDE_DIR ?= /usr/include/eigen3
 CC = g++
-CFLAGS = -std=c++11 -O3 -g -Wall -fopenmp -fPIC -I/usr/include \
+CFLAGS = -std=c++14 -O3 -g -Wall -fopenmp -fPIC -I/usr/include \
 	-I../include -I$(EIGEN_INCLUDE_DIR) -I$(GOOGLETEST_DIR)/include \
 	-march=native
 


### PR DESCRIPTION
**Context:**
MSVC 2015 (v14) apparently doesn't implement some features of C++11 correctly. It would be nice to support C++11 fully and C++14.

**Description of the Change:**
Change build flags and CI flags to support C++14.

**Benefits:**
Supports C++14

**Possible Drawbacks:**
Unknown

**Related GitHub Issues:**
