### PR TITLE
Add pytest randomly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -r requirements.txt
-            pip install pytest pytest-cov wheel codecov
+            pip install pytest pytest-cov pytest-randomly wheel codecov
             pip install -e .
       - save_cache:
           paths:
@@ -76,8 +76,8 @@ jobs:
     environment:
       CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
       CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
-      CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
-      CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus
+      CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-randomly
+      CIBW_TEST_COMMAND: python -m pytest --randomly-seed=41 {project}/thewalrus
     steps:
       - checkout
       - setup_remote_docker
@@ -110,8 +110,8 @@ jobs:
       CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
       CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=10.9"
       CIBW_BEFORE_BUILD_MACOS: brew cask uninstall --force oclint && brew install gcc eigen libomp || true; brew install gcc eigen libomp && pip install numpy scipy cython
-      CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov
-      CIBW_TEST_COMMAND: python -m pytest {project}/thewalrus
+      CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-randomly
+      CIBW_TEST_COMMAND: python -m pytest --randomly-seed=41 {project}/thewalrus
     steps:
       - checkout
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
 - |
     pip install -r requirements.txt
-    pip install pytest pytest-cov wheel codecov
+    pip install pytest pytest-cov pytest-randomly wheel codecov
     pip install -e .
 script:
 - make coverage

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COVERAGE3 := $(shell which coverage3 2>/dev/null)
 
 PYTHON := python3
 COVERAGE := --cov=thewalrus --cov-report term-missing --cov-report=html:coverage_html_report --cov-report=xml:coverage.xml
-TESTRUNNER := -m pytest thewalrus
+TESTRUNNER := -m pytest --randomly-seed=41 thewalrus
 
 .PHONY: help
 help:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ environment:
       TEST_TIMEOUT: 1000
       CIBW_BEFORE_BUILD: pip install numpy scipy cython
       CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* *win32"
-      CIBW_TEST_REQUIRES: "numpy scipy pytest pytest-cov"
-      CIBW_TEST_COMMAND: "python -m pytest {project}/thewalrus"
+      CIBW_TEST_REQUIRES: "numpy scipy pytest pytest-cov pytest-randomly"
+      CIBW_TEST_COMMAND: "python -m pytest --randomly-seed=41 {project}/thewalrus"
       CIBW_BUILD_VERBOSITY: 3
       WHEELHOUSE_UPLOADER_USERNAME: AKIAJOU6ECM5Q7T6UUQQ
       WHEELHOUSE_UPLOADER_SECRET:

--- a/thewalrus/tests/test_fock_gradients.py
+++ b/thewalrus/tests/test_fock_gradients.py
@@ -26,9 +26,6 @@ from thewalrus.fock_gradients import (
 import numpy as np
 
 
-# make tests deterministic
-np.random.seed(137)
-
 def test_grad_displacement():
     """Tests the value of the analytic gradient for the Dgate against finite differences"""
     cutoff = 4

--- a/thewalrus/tests/test_hafnian_approx.py
+++ b/thewalrus/tests/test_hafnian_approx.py
@@ -20,7 +20,6 @@ from scipy.special import factorial2, factorial as fac
 
 from thewalrus import hafnian, haf_real
 
-np.random.seed(137)
 
 @pytest.mark.parametrize("n", [6, 8, 10])
 def test_rank_one(n):

--- a/thewalrus/tests/test_low_rank_haf.py
+++ b/thewalrus/tests/test_low_rank_haf.py
@@ -19,8 +19,6 @@ from thewalrus import low_rank_hafnian, hafnian
 from thewalrus._low_rank_haf import partitions
 from scipy.special import binom
 
-np.random.seed(137)
-
 
 @pytest.mark.parametrize("n", [9, 11, 13])
 @pytest.mark.parametrize("r", [1, 2, 3])

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -64,10 +64,6 @@ from thewalrus.quantum import (
 )
 
 
-# make tests deterministic
-np.random.seed(137)
-
-
 @pytest.mark.parametrize("n", [0, 1, 2])
 def test_reduced_gaussian(n):
     """test that reduced gaussian returns the correct result"""

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -21,9 +21,6 @@ from scipy.linalg import block_diag
 from thewalrus import symplectic
 
 
-# make test deterministic
-np.random.seed(137)
-
 # pylint: disable=too-few-public-methods
 class TestVacuum:
     """Tests for the vacuum_state function"""


### PR DESCRIPTION
**Context:**
Some tests are failing randomly (specifically when adding new tests causing the order of the tests to change) due to a combination of them being random and that the seed that is set at the top of each file isn't actually resetting between tests at all (since all files are loaded prior to running any tests).

**Description of the Change:**
`pytest-randomly` is added as a dependency for the test suite, and is used for all CI tests as well as in the makefile. The seed is set to 41 everywhere. Also, the unnecessary `np.random.seed`s are removed from the test-files to avoid confusion.

**Benefits:**
 `pytest-randomly` provides 2 significant benefits:

1. The random seed is reset between each test.

2. The tests are shuffled, providing an extra layer of testing by making sure that no tests are dependent on the order by which they run.

**Possible Drawbacks:**
Since this changes the way the tests are run, some tests may fail further down the line. This should be considered good though, since it means that we will discover things that aren't working properly. Also, since the seed it set via the CI config files, it might be a bit confusing for some to know that there in fact is a seed set and where it is set (at least for those unfamiliar with `pytest-randomly`).

**Related GitHub Issues:**
None
