### PR TITLE
Fall back to using Ubuntu 18.04 for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   core-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
**Context:**
The tests are not running due to Ubuntu 20.04 being the [default version for the “ubuntu-latest” label](https://github.com/XanaduAI/thewalrus/pull/227#issue-572719607), causing the installation of `gcc-4.8` to fail, since it's no longer part of the distribution.  

**Description of the Change:**
`ubuntu-latest` is changed to `ubuntu-18.04` so that `gcc-4.8` can be installed correctly.

**Benefits:**
Tests can run correctly.

**Possible Drawbacks:**
We might want to either use a newer version of `gcc` in the future, or attempt to install it on `ubuntu-latest`, i.e. on Ubuntu 20.04.

**Related GitHub Issues:**
None
