### PR TITLE
 Pin docutils to version v0.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       - run:
           name: Build the Linux wheels.
           command: |
-            pip install --user cibuildwheel==1.1.0
+            pip install --user cibuildwheel==1.10
             python -m cibuildwheel --output-dir wheelhouse
       - run:
           name: Upload Linux wheels.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     docker:
       - image: circleci/python:3.6.12-stretch
     environment:
-      CIBW_SKIP: "cp27-* cp34-* cp35-* *i686"
+      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* *i686"
       CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-randomly
       CIBW_TEST_COMMAND: python -m pytest --randomly-seed=137 {project}/thewalrus
@@ -107,7 +107,7 @@ jobs:
     macos:
       xcode: "12.3.0"
     environment:
-      CIBW_SKIP: "pp* cp27-* cp34-* cp35-* cp39-* *i686"
+      CIBW_SKIP: "pp* cp27-* cp34-* cp35-* cp36-* *i686"
       CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=10.9"
 
       CIBW_BEFORE_BUILD_MACOS: brew install gcc eigen libomp; pip install numpy scipy cython

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     docker:
       - image: circleci/python:3.6.12-stretch
     environment:
-      CIBW_SKIP: "cp27-* cp34-* cp35-* cp36-* *i686"
+      CIBW_SKIP: "pp* cp27-* cp34-* cp35-* cp36-* *i686"
       CIBW_BEFORE_BUILD_LINUX: curl -OsL https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz && tar xzf eigen-3.3.7.tar.gz eigen-3.3.7/Eigen --strip-components 1 && cp -rf Eigen {project}/include && pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-randomly
       CIBW_TEST_COMMAND: python -m pytest --randomly-seed=137 {project}/thewalrus

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ environment:
   global:
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
+      PYTHON: "C:\\Python37"
       EIGEN_INCLUDE_DIR: C:\eigen-3.3.7\
       TEST_TIMEOUT: 1000
       CIBW_BEFORE_BUILD: pip install numpy scipy cython
@@ -18,8 +19,6 @@ cache:
 
 matrix:
   fast_finish: false
-  
-stack: python 3.7
 
 image: Visual Studio 2017
 
@@ -28,6 +27,7 @@ install:
   - cmd: 7z x eigen3.zip -o"C:\" -y > nul
 
 build_script:
+  - SET PATH=%PYTHON%;%PATH%
   - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   - pip install numpy scipy cython cibuildwheel==1.10
   - cibuildwheel --output-dir wheelhouse

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
       CIBW_BEFORE_BUILD: pip install numpy scipy cython
       CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* cp36-* *win32"
       CIBW_TEST_REQUIRES: "numpy scipy pytest pytest-cov pytest-randomly"
-      CIBW_TEST_COMMAND: "python3 -m pytest --randomly-seed=137 {project}/thewalrus"
+      CIBW_TEST_COMMAND: "python -m pytest --randomly-seed=137 {project}/thewalrus"
       CIBW_BUILD_VERBOSITY: 3
       WHEELHOUSE_UPLOADER_USERNAME: AKIAJOU6ECM5Q7T6UUQQ
       WHEELHOUSE_UPLOADER_SECRET:
@@ -18,6 +18,8 @@ cache:
 
 matrix:
   fast_finish: false
+  
+stack: python 3.7
 
 image: Visual Studio 2017
 
@@ -27,7 +29,7 @@ install:
 
 build_script:
   - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
-  - pip3 install numpy scipy cython cibuildwheel==1.10
+  - pip install numpy scipy cython cibuildwheel==1.10
   - cibuildwheel --output-dir wheelhouse
 
 artifacts:
@@ -49,6 +51,6 @@ for:
   configuration: Release
 
   after_build:
-    - pip3 install https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip
-    - pip3 install wheelhouse-uploader
-    - python3 -m wheelhouse_uploader upload --provider-name S3 --local-folder wheelhouse/ xanadu-wheels
+    - pip install https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip
+    - pip install wheelhouse-uploader
+    - python -m wheelhouse_uploader upload --provider-name S3 --local-folder wheelhouse/ xanadu-wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
       EIGEN_INCLUDE_DIR: C:\eigen-3.3.7\
       TEST_TIMEOUT: 1000
       CIBW_BEFORE_BUILD: pip install numpy scipy cython
-      CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* *win32"
+      CIBW_SKIP: "cp27-* cp33-* cp34-* cp35-* cp36-* *win32"
       CIBW_TEST_REQUIRES: "numpy scipy pytest pytest-cov pytest-randomly"
-      CIBW_TEST_COMMAND: "python -m pytest --randomly-seed=137 {project}/thewalrus"
+      CIBW_TEST_COMMAND: "python3 -m pytest --randomly-seed=137 {project}/thewalrus"
       CIBW_BUILD_VERBOSITY: 3
       WHEELHOUSE_UPLOADER_USERNAME: AKIAJOU6ECM5Q7T6UUQQ
       WHEELHOUSE_UPLOADER_SECRET:
@@ -27,7 +27,7 @@ install:
 
 build_script:
   - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
-  - pip install numpy scipy cython cibuildwheel==1.10
+  - pip3 install numpy scipy cython cibuildwheel==1.10
   - cibuildwheel --output-dir wheelhouse
 
 artifacts:
@@ -49,6 +49,6 @@ for:
   configuration: Release
 
   after_build:
-    - pip install https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip
-    - pip install wheelhouse-uploader
-    - python -m wheelhouse_uploader upload --provider-name S3 --local-folder wheelhouse/ xanadu-wheels
+    - pip3 install https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip
+    - pip3 install wheelhouse-uploader
+    - python3 -m wheelhouse_uploader upload --provider-name S3 --local-folder wheelhouse/ xanadu-wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
 
 build_script:
   - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
-  - pip install numpy scipy cython cibuildwheel==1.1.0
+  - pip install numpy scipy cython cibuildwheel==1.10
   - cibuildwheel --output-dir wheelhouse
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ environment:
   global:
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
-      PYTHON: "C:\\Python37"
       EIGEN_INCLUDE_DIR: C:\eigen-3.3.7\
       TEST_TIMEOUT: 1000
       CIBW_BEFORE_BUILD: pip install numpy scipy cython
@@ -22,12 +21,16 @@ matrix:
 
 image: Visual Studio 2017
 
+stack: python 3.7
+
+init:
+- cmd: set PATH=C:\Python37;C:\Python37\Scripts;%PATH%
+
 install:
   - ps: wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.zip -outfile eigen3.zip
   - cmd: 7z x eigen3.zip -o"C:\" -y > nul
 
 build_script:
-  - SET PATH=%PYTHON%;%PATH%
   - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   - pip install numpy scipy cython cibuildwheel==1.10
   - cibuildwheel --output-dir wheelhouse

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.16
 sphinxcontrib-bibtex
 sphinx==1.8.5
 ipykernel


### PR DESCRIPTION
[Docutils version 0.17](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-17-2021-04-03), released on April 3rd, contains a new HTML5 writer that uses HTML5 semantic tags (`<main>`, `<section>`, `<header>`, `<footer>`, `<aside>`, `<figure>`, and `<figcaption>`) rather than `<div>`. This breaks the CSS on the website.

This PR pins docutils to version 0.16.