### PR TITLE
Fix OSX wheel build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       CIBW_SKIP: "pp* cp27-* cp34-* cp35-* cp36-* *i686"
       CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=10.9"
 
-      CIBW_BEFORE_BUILD_MACOS: brew install gcc eigen libomp; pip install numpy scipy cython
+      CIBW_BEFORE_BUILD_MACOS: brew install gmp gcc eigen libomp; pip install numpy scipy cython
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-randomly
       CIBW_TEST_COMMAND: python -m pytest --randomly-seed=137 {project}/thewalrus
     steps:

--- a/setup.py
+++ b/setup.py
@@ -151,9 +151,9 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
Quick fix to get the OSX wheels to build. The issue was that brew implicitly tried to install `gmp 6.2.1` as a dependency for `gcc` using the wrong link. Just installing it manually seemingly fixed it.

Also, adds Python 3.9 to and removes Python 3.6 from `setup.py` (should already be fixed for tests and wheel-builds).