### PR TITLE
new torontonian sampling

### DIFF
--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -371,7 +371,7 @@ def generate_torontonian_sample(cov, mu=None, hbar=2, max_photons=30):
         probs[1] = threshold_detection_prob(mu_red, V_red, indices1, hbar=hbar)
 
         probs = np.real_if_close(probs)
-        probs = np.round(probs, 16)
+        probs[np.where(probs < 1e-11)] = 0.
         result = np.random.choice(range(2), p=probs / prev_prob)
 
         results.append(result)

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -57,12 +57,11 @@ import numpy as np
 from scipy.special import factorial as fac
 
 from ._hafnian import hafnian, reduction
-from ._torontonian import tor, threshold_detection_prob, threshold_detection_prob_displacement
+from ._torontonian import threshold_detection_prob
 from .quantum import (
     Amat,
     Covmat,
     Qmat,
-    Xmat,
     gen_Qmat_from_graph,
     is_classical_cov,
     reduced_gaussian,
@@ -367,10 +366,10 @@ def generate_torontonian_sample(cov, mu=None, hbar=2, max_photons=30):
         mu_red, V_red = reduced_gaussian(mu, cov, kk)
 
         indices0 = results + [0]
-        probs[0] = threshold_detection_prob(mu_red, V_red, indices0).real
+        probs[0] = threshold_detection_prob(mu_red, V_red, indices0, hbar=hbar).real
 
         indices1 = results + [1]
-        probs[1] = threshold_detection_prob(mu_red, V_red, indices1).real
+        probs[1] = threshold_detection_prob(mu_red, V_red, indices1, hbar=hbar).real
 
         result = np.random.choice(range(2), p=probs / prev_prob)
 

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -371,7 +371,7 @@ def generate_torontonian_sample(cov, mu=None, hbar=2, max_photons=30):
         probs[1] = threshold_detection_prob(mu_red, V_red, indices1, hbar=hbar)
 
         probs = np.real_if_close(probs)
-        probs[np.where(probs < 1e-11)] = 0.
+        probs = np.maximum(probs, 0)
         result = np.random.choice(range(2), p=probs / prev_prob)
 
         results.append(result)

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -79,7 +79,6 @@ __all__ = [
     "torontonian_sample_graph",
     "torontonian_sample_classical_state",
     "threshold_detection_prob",
-    "threshold_detection_prob_displacement",
     "photon_number_sampler",
 ]
 
@@ -460,8 +459,8 @@ def torontonian_sample_state(cov, samples, mu=None, hbar=2, max_photons=30, para
         np.array[int]:  threshold samples from the Gaussian state.
     """
 
-    if type(cov) is not np.ndarray:
-        raise TypeError("cov must be a numpy array")
+    if not isinstance(cov, np.ndarray):
+        raise TypeError("Covariance matrix must be a NumPy array.")
 
     if mu is None:
         M = cov.shape[0] // 2

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -370,6 +370,8 @@ def generate_torontonian_sample(cov, mu=None, hbar=2, max_photons=30):
         indices1 = results + [1]
         probs[1] = threshold_detection_prob(mu_red, V_red, indices1, hbar=hbar).real
 
+        probs = np.real_if_close(probs)
+        probs = np.round(probs, 16)
         result = np.random.choice(range(2), p=probs / prev_prob)
 
         results.append(result)

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -365,10 +365,10 @@ def generate_torontonian_sample(cov, mu=None, hbar=2, max_photons=30):
         mu_red, V_red = reduced_gaussian(mu, cov, kk)
 
         indices0 = results + [0]
-        probs[0] = threshold_detection_prob(mu_red, V_red, indices0, hbar=hbar).real
+        probs[0] = threshold_detection_prob(mu_red, V_red, indices0, hbar=hbar)
 
         indices1 = results + [1]
-        probs[1] = threshold_detection_prob(mu_red, V_red, indices1, hbar=hbar).real
+        probs[1] = threshold_detection_prob(mu_red, V_red, indices1, hbar=hbar)
 
         probs = np.real_if_close(probs)
         probs = np.round(probs, 16)

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -292,7 +292,6 @@ def hafnian_sample_state(
     return _hafnian_sample(params)
 
 
-
 def hafnian_sample_graph(
     A, n_mean, samples=1, cutoff=5, max_photons=30, approx=False, approx_samples=1e5, parallel=False
 ):
@@ -341,7 +340,7 @@ def generate_torontonian_sample(cov, mu=None, hbar=2, max_photons=30):
             representing an :math:`N` mode quantum state. This can be obtained
             via the ``scovmavxp`` method of the Gaussian backend of Strawberry Fields.
         mu (array): a :math:`2N` ``np.float64`` displacement vector
-            representing an :math:`N` mode quantum state. This can be obtained 
+            representing an :math:`N` mode quantum state. This can be obtained
             via the ``smeanxp`` method of the Gaussian backend of Strawberry Fields.
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`.
@@ -404,7 +403,7 @@ def _torontonian_sample(args):
 
             mu (array)
                 a :math:`2N` ``np.float64`` displacement vector
-                representing an :math:`N` mode quantum state. This can be obtained 
+                representing an :math:`N` mode quantum state. This can be obtained
                 via the ``smeanxp`` method of the Gaussian backend of Strawberry Fields.
 
             hbar (float)
@@ -451,7 +450,7 @@ def torontonian_sample_state(cov, samples, mu=None, hbar=2, max_photons=30, para
             via the ``scovmavxp`` method of the Gaussian backend of Strawberry Fields.
         samples (int): number of samples to generate
         mu (array): a :math:`2N` ``np.float64`` displacement vector
-            representing an :math:`N` mode quantum state. This can be obtained 
+            representing an :math:`N` mode quantum state. This can be obtained
             via the ``smeanxp`` method of the Gaussian backend of Strawberry Fields.
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`.
@@ -463,11 +462,10 @@ def torontonian_sample_state(cov, samples, mu=None, hbar=2, max_photons=30, para
     """
 
     if type(cov) is not np.ndarray:
-        raise TypeError('cov must be a numpy array')
-
+        raise TypeError("cov must be a numpy array")
 
     if mu is None:
-        M = cov.shape[0] // 2 
+        M = cov.shape[0] // 2
         mu = np.zeros(2 * M, dtype=np.float64)
 
     if parallel:
@@ -482,7 +480,6 @@ def torontonian_sample_state(cov, samples, mu=None, hbar=2, max_photons=30, para
 
     params = [cov, samples, mu, hbar, max_photons]
     return _torontonian_sample(params)
-
 
 
 def torontonian_sample_graph(A, n_mean, samples=1, max_photons=30, parallel=False):
@@ -501,7 +498,9 @@ def torontonian_sample_graph(A, n_mean, samples=1, max_photons=30, parallel=Fals
     """
     Q = gen_Qmat_from_graph(A, n_mean)
     cov = Covmat(Q, hbar=2)
-    return torontonian_sample_state(cov, samples, hbar=2, max_photons=max_photons, parallel=parallel)
+    return torontonian_sample_state(
+        cov, samples, hbar=2, max_photons=max_photons, parallel=parallel
+    )
 
 
 # pylint: disable=unused-argument
@@ -541,7 +540,7 @@ def hafnian_sample_classical_state(
 
 
 def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-08):
-    r""" Returns threshold samples from a Gaussian state that has a positive P function.
+    r"""Returns threshold samples from a Gaussian state that has a positive P function.
 
     Args:
         cov(array): a :math:`2N\times 2N` ``np.float64`` covariance matrix
@@ -579,11 +578,11 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
 
     if out_of_bounds is False:
         probabilities = probabilities.flatten() / sum_p
-        vals = np.arange(cutoff**num_modes, dtype=int)
+        vals = np.arange(cutoff ** num_modes, dtype=int)
         return [
             np.unravel_index(np.random.choice(vals, p=probabilities), [cutoff] * num_modes)
             for _ in range(num_samples)
-            ]
+        ]
 
     upper_limit = cutoff ** num_modes
 
@@ -593,12 +592,13 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
 
         return np.unravel_index(index, [cutoff] * num_modes)
 
-    vals = np.arange(1 + cutoff**num_modes, dtype=int)
+    vals = np.arange(1 + cutoff ** num_modes, dtype=int)
     probabilities = np.append(probabilities.flatten(), 1.0 - sum_p)
     return [sorter(np.random.choice(vals, p=probabilities)) for _ in range(num_samples)]
 
+
 def seed(seed_val=None):
-    r""" Seeds the random number generator used in the sampling algorithms.
+    r"""Seeds the random number generator used in the sampling algorithms.
 
     This function is a wrapper around ``numpy.random.seed()``. By setting the seed
     to a specific integer, the sampling algorithms will exhibit deterministic behaviour.
@@ -607,7 +607,6 @@ def seed(seed_val=None):
         seed_val (int): Seed for RandomState. Must be convertible to 32 bit unsigned integers.
     """
     np.random.seed(seed_val)
-
 
 
 def _hafnian_sample_graph_rank_one(G, n_mean):

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -453,7 +453,6 @@ class TestTorontonianSampling:
     @pytest.mark.parametrize("parallel", [True, False])
     def test_torontonian_sample_graph(self, parallel):
         """Test torontonian sampling from a graph"""
-        np.random.seed(42)
         A = np.array([[0, 3.0 + 4j], [3.0 + 4j, 0]])
         n_samples = 1000
         mean_n = 0.5

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -33,6 +33,7 @@ from thewalrus.samples import (
 )
 from thewalrus.quantum import gen_Qmat_from_graph, density_matrix_element, probabilities
 from thewalrus.symplectic import two_mode_squeezing
+
 seed(137)
 
 rel_tol = 3.0
@@ -44,7 +45,7 @@ def TMS_cov(r, phi, hbar=2):
 
     S = two_mode_squeezing(r, phi)
 
-    return S @ S.T * hbar/2
+    return S @ S.T * hbar / 2
 
 
 class TestHafnianSampling:
@@ -242,7 +243,13 @@ class TestHafnianSampling:
         n_mean = 2
         nr_samples = 10
         samples = hafnian_sample_graph(
-            A, n_mean, cutoff=5, approx=True, approx_samples=approx_samples, samples=nr_samples, parallel=parallel
+            A,
+            n_mean,
+            cutoff=5,
+            approx=True,
+            approx_samples=approx_samples,
+            samples=nr_samples,
+            parallel=parallel,
         )
 
         test_passed = True
@@ -369,8 +376,8 @@ class TestTorontonianSampling:
         """
         n_samples = 10000
 
-        sigma = np.array([[1., 0.], [0., 1.]])
-        mu = np.array([1., 1.])
+        sigma = np.array([[1.0, 0.0], [0.0, 1.0]])
+        mu = np.array([1.0, 1.0])
         samples = torontonian_sample_state(sigma, samples=n_samples, mu=mu)
 
         samples_list = list(samples)
@@ -414,8 +421,7 @@ class TestTorontonianSampling:
         "sample_func", [torontonian_sample_state, torontonian_sample_classical_state]
     )
     def test_multimode_vacuum_state_torontonian(self, sample_func):
-        """Test the sampling routines by checking the samples for pure vacuum
-        """
+        """Test the sampling routines by checking the samples for pure vacuum"""
         n_samples = 100
         n_modes = 10
         sigma = np.identity(2 * n_modes)
@@ -455,7 +461,7 @@ class TestTorontonianSampling:
 
 
 def test_photon_number_sampler_two_mode_squeezed():
-    """Test the brute force sampler when one truncates the probability distribution """
+    """Test the brute force sampler when one truncates the probability distribution"""
     hbar = 2.0
     r = np.arcsinh(1.0)
     cov = TMS_cov(r, 0.0)
@@ -472,8 +478,8 @@ def test_photon_number_sampler_out_of_bounds():
     cov = TMS_cov(r, 0.0)
     cutoff = 5
     probs = probabilities(np.zeros([4]), cov, cutoff, hbar=hbar)
-    samples = photon_number_sampler(probs, 1000, out_of_bounds='Coo coo ca choo')
-    assert 'Coo coo ca choo' in samples
+    samples = photon_number_sampler(probs, 1000, out_of_bounds="Coo coo ca choo")
+    assert "Coo coo ca choo" in samples
     numerical_samples = np.array([x for x in samples if x != "Coo coo ca choo"])
     assert np.allclose(numerical_samples[:, 0], numerical_samples[:, 1])
 
@@ -495,8 +501,7 @@ def test_seed():
 
 
 def test_out_of_bounds_generate_hafnian_sample():
-    """Check that when the sampled goes beyond max_photons a -1 is returned.
-    """
+    """Check that when the sampled goes beyond max_photons a -1 is returned."""
     n_samples = 100
     mean_n = 20
     r = np.arcsinh(np.sqrt(mean_n))
@@ -504,20 +509,24 @@ def test_out_of_bounds_generate_hafnian_sample():
 
     cutoff = 10
     max_photons = 5
-    samples = [generate_hafnian_sample(sigma, cutoff=cutoff, max_photons=max_photons) for i in range(n_samples)]
+    samples = [
+        generate_hafnian_sample(sigma, cutoff=cutoff, max_photons=max_photons)
+        for i in range(n_samples)
+    ]
     assert -1 in samples
 
 
 def test_out_of_bounds_generate_torontonian_sample():
-    """Check that when the sampled goes beyond max_photons a -1 is returned.
-    """
+    """Check that when the sampled goes beyond max_photons a -1 is returned."""
     n_samples = 100
     mean_n = 100
     r = np.arcsinh(np.sqrt(mean_n))
     sigma = TMS_cov(r, 0)
 
     max_photons = 1
-    samples = [generate_torontonian_sample(sigma, max_photons=max_photons) for i in range(n_samples)]
+    samples = [
+        generate_torontonian_sample(sigma, max_photons=max_photons) for i in range(n_samples)
+    ]
     assert -1 in samples
 
 
@@ -528,9 +537,7 @@ def test_hafnian_sample_graph_rank_one():
     n_samples = 100000
     samples = hafnian_sample_graph_rank_one(G, n_mean, n_samples)
     # Check the total mean photon number is correct
-    assert np.allclose(
-        np.mean(samples.sum(axis=1)), n_mean, atol=10 / np.sqrt(n_samples)
-    )
+    assert np.allclose(np.mean(samples.sum(axis=1)), n_mean, atol=10 / np.sqrt(n_samples))
     # Check the standard deviation of the total mean photon number is correct
     assert np.allclose(
         np.std(samples.sum(axis=1)),

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -453,6 +453,7 @@ class TestTorontonianSampling:
     @pytest.mark.parametrize("parallel", [True, False])
     def test_torontonian_sample_graph(self, parallel):
         """Test torontonian sampling from a graph"""
+        np.random.seed(42)
         A = np.array([[0, 3.0 + 4j], [3.0 + 4j, 0]])
         n_samples = 1000
         mean_n = 0.5

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -363,6 +363,26 @@ class TestTorontonianSampling:
             rel_freq, x2, atol=rel_tol / np.sqrt(n_samples), rtol=rel_tol / np.sqrt(n_samples)
         )
 
+    def test_single_coherent_state_torontonian(self):
+        """Test the sampling routines by comparing the photon number frequencies and the exact
+        probability distribution of a single mode squeezed vacuum state
+        """
+        n_samples = 10000
+        mean_n = 1.0
+        alpha = np.sqrt(mean_n)
+        sigma = np.array([[1., 0.], [0., 1.]])
+        mu = np.array([1., 0.])
+        samples = torontonian_sample_state(sigma, samples=n_samples, mu=mu)
+
+        samples_list = list(samples)
+
+        rel_freq = np.array([samples_list.count(0), samples_list.count(1)]) / n_samples
+
+        x2 = np.array([np.exp(-1), 1 - np.exp(-1)])
+        assert np.allclose(
+            rel_freq, x2, atol=rel_tol / np.sqrt(n_samples), rtol=rel_tol / np.sqrt(n_samples)
+        )
+
     def test_two_mode_squeezed_state_torontonian(self):
         """Test the sampling routines by comparing the photon number frequencies and the exact
         probability distribution of a two mode squeezed vacuum state

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -368,17 +368,15 @@ class TestTorontonianSampling:
         probability distribution of a single mode squeezed vacuum state
         """
         n_samples = 10000
-        mean_n = 1.0
-        alpha = np.sqrt(mean_n)
+
         sigma = np.array([[1., 0.], [0., 1.]])
-        mu = np.array([1., 0.])
+        mu = np.array([1., 1.])
         samples = torontonian_sample_state(sigma, samples=n_samples, mu=mu)
 
         samples_list = list(samples)
 
         rel_freq = np.array([samples_list.count(0), samples_list.count(1)]) / n_samples
-
-        x2 = np.array([np.exp(-1), 1 - np.exp(-1)])
+        x2 = np.array([np.exp(-0.5), 1 - np.exp(-0.5)])
         assert np.allclose(
             rel_freq, x2, atol=rel_tol / np.sqrt(n_samples), rtol=rel_tol / np.sqrt(n_samples)
         )


### PR DESCRIPTION
**Context:**
the old torontonian sampling function using tor, and so could not be used for states with displacement. It was also a little clumsy.

**Description of the Change:**
The function now calls ``threshold_detection_prob``, making the code a bit cleaner and importantly also allows for displaced Gaussian states to be sampled from.

**Benefits:**
Cleaner code, nonzero displacement now allowed.

**Possible Drawbacks:**
We could do some clever things to speed it up slightly.

**Related GitHub Issues:**
