### PR TITLE
modify generate_hafnian_sample to renormalize probabilities

### DIFF
--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -153,10 +153,9 @@ def generate_hafnian_sample(
         if ssum < 1.0:
             probs3[-1] = 1.0 - ssum
 
-        # The following normalization of probabilities is needed when approx=True
-        if approx:
-            if ssum > 1.0:
-                probs3 = probs3 / ssum
+        # The following normalization of probabilities is needed to prevent np.random.choice error
+        if ssum > 1.0:
+            probs3 = probs3 / ssum
 
         result.append(np.random.choice(a=range(len(probs3)), p=probs3))
         if result[-1] == cutoff:


### PR DESCRIPTION
**Context:**
This PR modifies the `generate_hafnian_sample` function by renormalizing probabilities. The sum of the computed probabilities in this function is sometimes slightly larger than `1.0` which leads to an error in generating random samples with `numpy.random.choice`. This error prevents simulating the vibronic properties of large molecules. 

**Description of the Change:**
The `if` statement in line 157 of `samples.py` is removed such that the probabilities are always renormalized if their sum is larger than 1.0. 

**Related GitHub Issues:**
https://github.com/XanaduAI/strawberryfields/issues/597