### PR TITLE
Add support for calculating the permanent using the BBFG algorithm

### DIFF
--- a/.github/ACKNOWLEDGMENTS.md
+++ b/.github/ACKNOWLEDGMENTS.md
@@ -46,4 +46,4 @@
 
 * [Yuan Yao](https://github.com/sylviemonet) (Télécom Paris) - :dog: Schrödinger's Dog's owner
 
-* [Ali Asadi](https://github.com/maliasadi) (Western University)
+* [Ali Asadi](https://github.com/maliasadi) (Western University) - :thread: Commander of threads

--- a/.github/ACKNOWLEDGMENTS.md
+++ b/.github/ACKNOWLEDGMENTS.md
@@ -45,3 +45,5 @@
 * [Timjan Kalajdzievski](https://github.com/timjank) (Xanadu) - :beverage_box: Beard Czar
 
 * [Yuan Yao](https://github.com/sylviemonet) (Télécom Paris) - :dog: Schrödinger's Dog's owner
+
+* [Ali Asadi](https://github.com/maliasadi) (Western University)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Adds the ability to calculate cumulants and arbitrary expectation values of products of powers of photon numbers with the functions `photon_number_cumulant` and `photon_number_moment` respectively  
 [#264](https://github.com/XanaduAI/thewalrus/pull/264)
 
-* Adds support for calculating the permanent using the BBFG algorithm [#263](https://github.com/XanaduAI/thewalrus/issues/263) 
+* Adds support for calculating the permanent using the BBFG algorithm [#267](https://github.com/XanaduAI/thewalrus/pull/267)
 
 ### Improvements
 
@@ -42,7 +42,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Jake Bulmer, Timjan Kalajdzievski, Filippo Miatto, Nicolas Quesada, Yuan Yao
+Ali Asadi, Jake Bulmer, Timjan Kalajdzievski, Filippo Miatto, Nicolas Quesada, Yuan Yao
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Adds the ability to calculate cumulants and arbitrary expectation values of products of powers of photon numbers with the functions `photon_number_cumulant` and `photon_number_moment` respectively  
 [#264](https://github.com/XanaduAI/thewalrus/pull/264)
 
+* Adds support for calculating the permanent using the BBFG algorithm [#263](https://github.com/XanaduAI/thewalrus/issues/263) 
+
 ### Improvements
 
 * Speeds up the calculation of photon number variances/covariances [#244](https://github.com/XanaduAI/thewalrus/pull/244)

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -433,8 +433,8 @@ inline T perm_BBFG_serial(std::vector<T> &mat)
  * \endrst
  *
  * This is a wrapper for computing permanent of a matrix based on 
- * Balasubramanian-Bax-Franklin-Glynn formula. For now, it is just 
- * calling a serial version of this algorithm using Gray code ordering. 
+ * Balasubramanian-Bax-Franklin-Glynn formula. For now, a serial 
+ * version of this algorithm using Gray code ordering is called. 
  * 
  * @param mat  a flattened vector of size \f$n^2\f$, representing an
  *      \f$n\times n\f$ row-ordered symmetric matrix.
@@ -453,7 +453,7 @@ inline T perm_BBFG(std::vector<T> &mat)
  * This algorithm was given by Glynn (2010) with the time-complexity 
  * of \f$O(n 2^n)\f$ using Gray code ordering.
  *
- * \endrstlocalsum
+ * \endrst
  *
  * This is a wrapper around the templated function `libwalrus::perm_BBFG` 
  * for Python integration. It accepts and returns double numeric types, 

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -83,6 +83,21 @@ static inline std::vector<int> dec2bin(llint &k, int &n)
     return mat;
 }
 
+/**
+ * Get the next ordering index
+ *
+ * @param \f$l\f$
+ * @param \f$k\f$
+ * @return the \f$k+1\f$-th ordering index with updating \f$l\f$ from init index \f$k\f$
+ */
+static inline size_t next_perm_ordering_index(std::vector<size_t> &l, size_t k)
+{
+    l[0] = 0;
+    l[k] = l[k+1];
+    l[k+1] = k+1;
+    return l[0];
+}
+
 namespace libwalrus {
 
 /**
@@ -481,15 +496,10 @@ inline T perm_BBFG_serial2(std::vector<T> &mat)
         coeffs[k] = -coeffs[k];
         sgn = -sgn; 
         total += sgn > 0 ? mulcolsum : -mulcolsum;
-
-        // update ordering 
-        grays[0] = 0;
-        grays[k] = grays[k+1];
-        grays[k+1] = k+1;
-        k = grays[0];
+        k = next_perm_ordering_index(grays, k);
     }
 
-     // TODO: overflow handling
+    // TODO: overflow handling
     return total / x;
 }
 

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -354,7 +354,6 @@ double permanent_fsum(std::vector<double> &mat)
 }
 
 
-
 /**
  * Returns the permanent of a matrix (nthreads=1)
  *
@@ -418,21 +417,40 @@ inline T perm_BBFG_serial(std::vector<T> &mat)
     }
 
     // TODO: overflow handling
+
     return total / static_cast<T>(x);
 }
 
+/**
+ * Returns the permanent of a matrix (nthreads=1) (2nd version)
+ *
+ * \rst
+ *
+ * Returns the permanent of a matrix using the BBFG algorithm.
+ * This algorithm was given by Glynn (2010) with the time-complexity 
+ * of \f$O(n 2^n)\f$ using Gray code ordering.
+ *
+ * \endrst
+ *
+ *
+ * @param mat  a flattened vector of size \f$n^2\f$, representing an
+ *      \f$n\times n\f$ row-ordered symmetric matrix.
+ * @return permanent of the input matrix 
+ */
 template <typename T>
 inline T perm_BBFG_serial2(std::vector<T> &mat)
 {
     int n = std::sqrt(static_cast<double>(mat.size()));
     int sgn=1, k=0;
 
+    constexpr T p2 = static_cast<T>(2.0);
+    constexpr T p1 = static_cast<T>(1.0);
+
     int *gray_list = new int[n];
     T *coeffs = new T[n];
-    std::fill_n(coeffs, n, static_cast<T>(2.0));
+    std::fill_n(coeffs, n, p2);
 
     std::vector<T> col_sum(n, static_cast<T>(0));
-    constexpr T p1 = static_cast<T>(1.0);
     T mulcolsum, total = p1; 
 
     // init col_sum 
@@ -470,9 +488,8 @@ inline T perm_BBFG_serial2(std::vector<T> &mat)
     delete[] coeffs;
 
     // TODO: overflow handling 
-    T x = static_cast<T>(pow(2,n - 1));    
 
-    return total / x;
+    return total / static_cast<T>(pow(2,n - 1));
 }
 
 /**

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -110,10 +110,10 @@ namespace libwalrus {
  *
  * \endrst
  *
- *
- * @param mat  a flattened vector of size \f$n^2\f$, representing an
+ * 
+ * @tparam T type of the matrix data
+ * @param mat a flattened vector of size \f$n^2\f$, representing an
  *      \f$n\times n\f$ row-ordered symmetric matrix.
- * @tparam T 
  * @return permanent of the input matrix
  */
 template <typename T>
@@ -205,11 +205,11 @@ inline T permanent(std::vector<T> &mat)
  * with Gray code ordering.
  *
  * \endrst
- *
- *
- * @param mat  a flattened vector of size \f$n^2\f$, representing an
+ * 
+ * 
+ * @tparam T type of the matrix data
+ * @param mat a flattened vector of size \f$n^2\f$, representing an
  *      \f$n\times n\f$ row-ordered symmetric matrix.
- * @tparam T 
  * @return permanent of the input matrix
  */
 template <typename T>
@@ -309,6 +309,7 @@ inline double perm_fsum(std::vector<T> &mat)
  * to type `complex<long double>`, allowing for greater precision than 
  * supported by Python and NumPy.
  *
+ * 
  * @param mat vector representing the flattened matrix
  * @return the permanent
  */
@@ -336,6 +337,7 @@ std::complex<double> permanent_quad(std::vector<std::complex<double>> &mat)
  * to type `long double`, allowing for greater precision than supported
  * by Python and NumPy.
  *
+ * 
  * @param mat vector representing the flattened matrix
  * @return the permanent
  */
@@ -381,17 +383,22 @@ double permanent_fsum(std::vector<double> &mat)
  *
  * \endrst
  *
- *
- * @param mat  a flattened vector of size \f$n^2\f$, representing an
+ * 
+ * @tparam T type of the matrix data 
+ * @param mat a flattened vector of size \f$n^2\f$, representing an
  *      \f$n\times n\f$ row-ordered symmetric matrix.
- * @tparam T 
  * @return permanent of the input matrix
  */
 template <typename T>
 inline T perm_BBFG_serial(std::vector<T> &mat) 
 {
     const size_t n = static_cast<size_t>(std::sqrt(static_cast<double>(mat.size())));
-    const ullint x = static_cast<ullint>(pow(2,n - 1));
+    const double p = pow(2, n-1);
+    const ullint x = static_cast<ullint>(p);
+    if (p != x) {
+        std::cerr << "overflow to inf" << std::endl;
+        exit(EXIT_FAILURE);
+    }
 
     constexpr T p1 = static_cast<T>(1.0);
     constexpr T p2 = static_cast<T>(2.0);
@@ -435,7 +442,6 @@ inline T perm_BBFG_serial(std::vector<T> &mat)
         og = ng;
     }
 
-    // TODO: overflow handling
     return total / static_cast<T>(x);
 }
 
@@ -449,19 +455,24 @@ inline T perm_BBFG_serial(std::vector<T> &mat)
  * of \f$O(n 2^n)\f$ using Gray code ordering.
  *
  * \endrst
- *
- *
+ * 
+ * 
+ * @tparam T type of the matrix data
  * @param mat a flattened vector of size \f$n^2\f$, representing an
  *      \f$n\times n\f$ row-ordered symmetric matrix.
- * @tparam T 
  * @return permanent of the input matrix 
  */
 template <typename T>
 inline T perm_BBFG_serial2(std::vector<T> &mat)
 {
     const size_t n = static_cast<size_t>(std::sqrt(static_cast<double>(mat.size())));
-    const T x = static_cast<T>(pow(2,n-1));
-    
+    const long double p = pow(2, n-1);
+    const T x = static_cast<T>(p);
+    if (p == HUGE_VAL || p != x) {
+        std::cerr << "overflow to inf" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
     constexpr T p2 = static_cast<T>(2.0);
     constexpr T p1 = static_cast<T>(1.0);
     constexpr T zero = static_cast<T>(0);
@@ -499,7 +510,6 @@ inline T perm_BBFG_serial2(std::vector<T> &mat)
         k = next_perm_ordering_index(grays, k);
     }
 
-    // TODO: overflow handling
     return total / x;
 }
 
@@ -514,17 +524,17 @@ inline T perm_BBFG_serial2(std::vector<T> &mat)
  *
  * \endrst
  *
- * This is a wrapper for computing permanent of a matrix based on 
- * Balasubramanian-Bax-Franklin-Glynn formula. For now, a serial 
- * version of this algorithm using Gray code ordering is called. 
+ * This is a wrapper function for computing permanent of a matrix 
+ * based on Balasubramanian-Bax-Franklin-Glynn (BBFG) formula.
  * 
- * @param mat  a flattened vector of size \f$n^2\f$, representing an
+ * 
+ * @tparam T type of the matrix data
+ * @param mat a flattened vector of size \f$n^2\f$, representing an
  *      \f$n\times n\f$ row-ordered symmetric matrix.
  * @return permanent of the input matrix
  */
 template <typename T>
-inline T perm_BBFG(std::vector<T> &mat) 
-{
+inline T perm_BBFG(std::vector<T> &mat) {
     return perm_BBFG_serial2(mat);   
 }
 
@@ -545,6 +555,7 @@ inline T perm_BBFG(std::vector<T> &mat)
  * to type `long double`, allowing for greater precision than supported
  * by Python and NumPy.
  *
+ * 
  * @param mat vector representing the flattened matrix
  * @return the permanent
  */
@@ -572,6 +583,7 @@ double perm_BBFG_qp(std::vector<double> &mat)
  * to type `complex<long double>`, allowing for greater precision than 
  * supported by Python and NumPy.
  *
+ * 
  * @param mat vector representing the flattened matrix
  * @return the permanent
  */

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -372,6 +372,7 @@ double permanent_fsum(std::vector<double> &mat)
     return static_cast<double>(perm);
 }
 
+
 /**
  * Returns the permanent of a matrix (nthreads=1)
  *

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -376,16 +376,7 @@ inline T perm_BBFG_serial(std::vector<T> &mat)
 {
     int n = std::sqrt(static_cast<double>(mat.size()));
     llint x = static_cast<llint>(pow(2,n - 1));
-    
-    T localsum, coeff;
-    T total = static_cast<T>(0);
     std::vector<T> col_sum(n, static_cast<T>(0));
-    llint og=0, ng, gd;
-    int sgn=1, gdi;
-   
-    constexpr T p1 = static_cast<T>(1.0);
-    constexpr T p2 = static_cast<T>(2.0);
-    constexpr T n2 = static_cast<T>(-2.0);
 
     // init col_sum 
     for (int i=0; i < n; ++i) {
@@ -394,16 +385,25 @@ inline T perm_BBFG_serial(std::vector<T> &mat)
         }
     }
 
-    // over all permutations of delta
+    constexpr T p1 = static_cast<T>(1.0);
+    constexpr T p2 = static_cast<T>(2.0);
+    constexpr T n2 = static_cast<T>(-2.0);
+
+    T mulcolsum, coeff;
+    T total = static_cast<T>(0);
+    llint og=0, ng, gd;
+    int sgn=1, gdi;
+
+    // over all 2^{n-1} permutations of delta
     for (llint k=1; k < x+1; ++k) {
-        localsum = std::accumulate(
+        mulcolsum = std::accumulate(
                         col_sum.begin(), 
                         col_sum.end(), 
                         p1, 
                         std::multiplies<T>());
-        total += sgn > 0 ? localsum : -localsum;
+        total += sgn > 0 ? mulcolsum : -mulcolsum;
         
-        // updating gray order 
+        // updating gray order
         ng = igray(k);
         gd = og ^ ng;
 
@@ -453,7 +453,7 @@ inline T perm_BBFG(std::vector<T> &mat)
  * This algorithm was given by Glynn (2010) with the time-complexity 
  * of \f$O(n 2^n)\f$ using Gray code ordering.
  *
- * \endrst
+ * \endrstlocalsum
  *
  * This is a wrapper around the templated function `libwalrus::perm_BBFG` 
  * for Python integration. It accepts and returns double numeric types, 

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -34,7 +34,7 @@ typedef long double qp;
  * @param n
  * @return the corresponding Gray code
  */
-llint igray(llint n)
+static inline llint igray(llint n)
 {
     /* Right Shift the number by 1
        taking xor with original number */
@@ -47,18 +47,17 @@ llint igray(llint n)
  * @param n
  * @return the left most set bit
  */
-int left_most_set_bit(llint n) {
-
-    if ( n == 0)
+static inline int left_most_set_bit(llint n) 
+{
+    if (n == 0)
         return 0;
 
     int msb = 0;
 
-    while ( n != 0) {
+    while (n != 0) {
         n = n / 2;
         msb++;
     }
-
     return msb;
 }
 
@@ -70,8 +69,8 @@ int left_most_set_bit(llint n) {
  * @param \f$n\f$
  * @return \f$n\f$ bit binary representation of integer \f$k\f$
  */
-std::vector<int> dec2bin(llint &k, int &n) {
-
+static inline std::vector<int> dec2bin(llint &k, int &n) 
+{
     llint kk = k;
     int i = n;
     std::vector<int> mat(n, 0);
@@ -84,16 +83,15 @@ std::vector<int> dec2bin(llint &k, int &n) {
     return mat;
 }
 
-
-
 namespace libwalrus {
 
 /**
- * Returns the permanent of an matrix.
+ * Returns the permanent of a matrix.
  *
  * \rst
  *
- * Returns the permanent of a matrix using Ryser's algorithm with Gray code ordering.
+ * Returns the permanent of a matrix using Ryser's algorithm 
+ * with Gray code ordering, that has a time-complexity of \f$O(n 2^n)\f$
  *
  * \endrst
  *
@@ -103,7 +101,8 @@ namespace libwalrus {
  * @return permanent of the input matrix
  */
 template <typename T>
-inline T permanent(std::vector<T> &mat) {
+inline T permanent(std::vector<T> &mat) 
+{
     int n = std::sqrt(static_cast<double>(mat.size()));
     llint x = static_cast<llint>(pow(2,n) - 1) ;
 
@@ -120,7 +119,6 @@ inline T permanent(std::vector<T> &mat) {
     std::vector<llint> threadbound_hi(nthreads);
 
     for (int i=0; i < nthreads; i++) {
-
         threadbound_low[i] = i*x/nthreads;
         threadbound_hi[i] = (i+1)*x/nthreads;
     }
@@ -136,21 +134,22 @@ inline T permanent(std::vector<T> &mat) {
         for (llint k = threadbound_low[ii]; k < threadbound_hi[ii]; k++) {
             T rowsumprod = static_cast<T>(1);
             llint kg2 = igray(k+1);
-            llint  sgntmp = kg2 - igray(k);
-            llint  sig = sgntmp/std::abs(sgntmp);
-            int  pos = 0;
-
-            pos = n - left_most_set_bit(sgntmp);
+            llint sgntmp = kg2 - igray(k);
+            llint sig = sgntmp/std::abs(sgntmp);
+            int pos = n - left_most_set_bit(sgntmp);
 
             if ( k == threadbound_low[ii] ) {
                 chitmp = dec2bin(kg2, n);
 
+                // loop rows of the k-th submatrix
                 for ( int j = 0; j < n; j++) {
                     T localsum = static_cast<T>(0);
                     for (int id = 0; id < n; id++) {
                         localsum += static_cast<T>(chitmp[id]) * mat[id*n+j];
                     }
                     tmp[j] += localsum;
+
+                    // update product of row sums 
                     rowsumprod *= tmp[j];
                 }
 
@@ -181,14 +180,13 @@ inline T permanent(std::vector<T> &mat) {
     return static_cast<T>(std::accumulate(tot.begin(), tot.end(), static_cast<T>(0)));
 }
 
-
-
 /**
- * Returns the permanent of an matrix using fsum.
+ * Returns the permanent of a matrix using fsum.
  *
  * \rst
  *
- * Returns the permanent of a matrix using Ryser's algorithm with Gray code ordering.
+ * Returns the permanent of a matrix using Ryser's algorithm 
+ * with Gray code ordering.
  *
  * \endrst
  *
@@ -198,7 +196,8 @@ inline T permanent(std::vector<T> &mat) {
  * @return permanent of the input matrix
  */
 template <typename T>
-inline double perm_fsum(std::vector<T> &mat) {
+inline double perm_fsum(std::vector<T> &mat) 
+{
     int n = std::sqrt(static_cast<double>(mat.size()));
     llint x = static_cast<llint>(pow(2,n) - 1) ;
 
@@ -215,7 +214,6 @@ inline double perm_fsum(std::vector<T> &mat) {
     std::vector<llint> threadbound_hi(nthreads);
 
     for (int i=0; i < nthreads; i++) {
-
         threadbound_low[i] = i*x/nthreads;
         threadbound_hi[i] = (i+1)*x/nthreads;
     }
@@ -277,27 +275,28 @@ inline double perm_fsum(std::vector<T> &mat) {
     return static_cast<T>(std::accumulate(tot.begin(), tot.end(), static_cast<T>(0)));
 }
 
-
 /**
  * \rst
  *
- * Returns the permanent of a matrix using the Ryser's algo with Gray code ordering
+ * Returns the permanent of a matrix using the Ryser's algo 
+ * with Gray code ordering
  *
  * \endrst
  *
  *
- * This is a wrapper around the templated function `libwalrus::permanent` for Python
- * integration. It accepts and returns complex double numeric types, and
- * returns sensible values for empty and non-even matrices.
+ * This is a wrapper around the templated function `libwalrus::permanent` 
+ * for Python integration. It accepts and returns complex double numeric types, 
+ * and returns sensible values for empty and non-even matrices.
  *
  * In addition, this wrapper function automatically casts all matrices
- * to type `complex<long double>`, allowing for greater precision than supported
- * by Python and NumPy.
+ * to type `complex<long double>`, allowing for greater precision than 
+ * supported by Python and NumPy.
  *
  * @param mat vector representing the flattened matrix
  * @return the permanent
  */
-std::complex<double> permanent_quad(std::vector<std::complex<double>> &mat) {
+std::complex<double> permanent_quad(std::vector<std::complex<double>> &mat) 
+{
     std::vector<std::complex<long double>> matq(mat.begin(), mat.end());
     std::complex<long double> perm = permanent(matq);
     return static_cast<std::complex<double>>(perm);
@@ -306,14 +305,15 @@ std::complex<double> permanent_quad(std::vector<std::complex<double>> &mat) {
 /**
  * \rst
  *
- * Returns the permanent of a matrix using Ryser's algo with Gray code ordering
+ * Returns the permanent of a matrix using Ryser's algo 
+ * with Gray code ordering
  *
  * \endrst
  *
  *
- * This is a wrapper around the templated function `libwalrus::permanent` for Python
- * integration. It accepts and returns double numeric types, and
- * returns sensible values for empty and non-even matrices.
+ * This is a wrapper around the templated function `libwalrus::permanent` 
+ * for Python integration. It accepts and returns double numeric types, 
+ * and returns sensible values for empty and non-even matrices.
  *
  * In addition, this wrapper function automatically casts all matrices
  * to type `long double`, allowing for greater precision than supported
@@ -322,34 +322,182 @@ std::complex<double> permanent_quad(std::vector<std::complex<double>> &mat) {
  * @param mat vector representing the flattened matrix
  * @return the permanent
  */
-double permanent_quad(std::vector<double> &mat) {
+double permanent_quad(std::vector<double> &mat) 
+{
     std::vector<qp> matq(mat.begin(), mat.end());
     qp perm = permanent(matq);
+    return static_cast<double>(perm);
+}
+
+/**
+ * \rst
+ *
+ * Returns the permanent of a matrix using Ryser's algo 
+ * with Gray code ordering with fsum
+ *
+ * \endrst
+ *
+ *
+ * This is a wrapper around the templated function `libwalrus::perm_fsum` 
+ * for Python integration. It accepts and returns double numeric types, 
+ * and returns sensible values for empty and non-even matrices.
+ *
+ *
+ * @param mat vector representing the flattened matrix
+ * @return the permanent
+ */
+double permanent_fsum(std::vector<double> &mat) 
+{
+    std::vector<double> matq(mat.begin(), mat.end());
+    double perm = perm_fsum(matq);
     return static_cast<double>(perm);
 }
 
 
 
 /**
+ * Returns the permanent of a matrix (nthreads=1)
+ *
  * \rst
  *
- * Returns the permanent of a matrix using Ryser's algo with Gray code ordering with fsum
+ * Returns the permanent of a matrix using the BBFG algorithm.
+ * This algorithm was given by Glynn (2010) with the time-complexity 
+ * of \f$O(n 2^n)\f$ using Gray code ordering.
  *
  * \endrst
  *
  *
- * This is a wrapper around the templated function `libwalrus::perm_fsum` for Python
- * integration. It accepts and returns double numeric types, and
- * returns sensible values for empty and non-even matrices.
+ * @param mat  a flattened vector of size \f$n^2\f$, representing an
+ *      \f$n\times n\f$ row-ordered symmetric matrix.
+ * @return permanent of the input matrix
+ */
+template <typename T>
+inline T perm_BBFG_serial(std::vector<T> &mat) 
+{
+    int n = std::sqrt(static_cast<double>(mat.size()));
+    llint x = static_cast<llint>(pow(2,n - 1));
+    
+    T localsum, coeff;
+    T total = static_cast<T>(0);
+    std::vector<T> col_sum(n, static_cast<T>(0));
+    llint og=0, ng, gd;
+    int sgn=1, gdi;
+   
+    constexpr T p1 = static_cast<T>(1.0);
+    constexpr T p2 = static_cast<T>(2.0);
+    constexpr T n2 = static_cast<T>(-2.0);
+
+    // init col_sum 
+    for (int i=0; i < n; ++i) {
+        for (int j=0; j < n; ++j) {
+            col_sum[i] += mat[j*n + i];
+        }
+    }
+
+    // over all permutations of delta
+    for (llint k=1; k < x+1; ++k) {
+        localsum = std::accumulate(
+                        col_sum.begin(), 
+                        col_sum.end(), 
+                        p1, 
+                        std::multiplies<T>());
+        total += sgn > 0 ? localsum : -localsum;
+        
+        // updating gray order 
+        ng = igray(k);
+        gd = og ^ ng;
+
+        coeff = og > ng ? p2 : n2;
+        gdi = left_most_set_bit(gd);
+        for (int j=0; j < n; ++j) {
+            col_sum[j] += coeff * mat[gdi * n + j];
+        }
+
+        sgn = -sgn;
+        og = ng;
+    }
+
+    return total / static_cast<T>(x);
+}
+
+
+/**
+ * Returns the permanent of a matrix
  *
+ * \rst
+ *
+ * Returns the permanent of a matrix using the BBFG algorithm.
+ * This algorithm was given by Glynn (2010) with the time-complexity 
+ * of \f$O(n 2^n)\f$ using Gray code ordering.
+ *
+ * \endrst
+ *
+ * This is a wrapper for computing permanent of a matrix based on 
+ * Balasubramanian-Bax-Franklin-Glynn formula. For now, it is just 
+ * calling a serial version of this algorithm using Gray code ordering. 
+ * 
+ * @param mat  a flattened vector of size \f$n^2\f$, representing an
+ *      \f$n\times n\f$ row-ordered symmetric matrix.
+ * @return permanent of the input matrix
+ */
+template <typename T>
+inline T perm_BBFG(std::vector<T> &mat) 
+{
+    return perm_BBFG_serial(mat);   
+}
+
+/**
+ * \rst
+ *
+ * Returns the permanent of a matrix using the BBFG formula.
+ * This algorithm was given by Glynn (2010) with the time-complexity 
+ * of \f$O(n 2^n)\f$ using Gray code ordering.
+ *
+ * \endrst
+ *
+ * This is a wrapper around the templated function `libwalrus::perm_BBFG` 
+ * for Python integration. It accepts and returns double numeric types, 
+ * and returns sensible values for empty and non-even matrices.
+ *
+ * In addition, this wrapper function automatically casts all matrices
+ * to type `long double`, allowing for greater precision than supported
+ * by Python and NumPy.
  *
  * @param mat vector representing the flattened matrix
  * @return the permanent
  */
-double permanent_fsum(std::vector<double> &mat) {
-    std::vector<double> matq(mat.begin(), mat.end());
-    double perm = perm_fsum(matq);
+double perm_BBFG_qp(std::vector<double> &mat) 
+{
+    std::vector<qp> matqp(mat.begin(), mat.end());
+    qp perm = perm_BBFG(matqp);
     return static_cast<double>(perm);
+}
+
+/**
+ * \rst
+ *
+ * Returns the permanent of a matrix using the BBFG formula.
+ * This algorithm was given by Glynn (2010) with the time-complexity 
+ * of \f$O(n 2^n)\f$ using Gray code ordering.
+ *
+ * \endrst
+ *
+ * This is a wrapper around the templated function `libwalrus::perm_BBFG` 
+ * for Python integration. It accepts and returns complex double numeric types, 
+ * and returns sensible values for empty and non-even matrices.
+ *
+ * In addition, this wrapper function automatically casts all matrices
+ * to type `complex<long double>`, allowing for greater precision than 
+ * supported by Python and NumPy.
+ *
+ * @param mat vector representing the flattened matrix
+ * @return the permanent
+ */
+std::complex<double> perm_BBFG_cmplx(std::vector<std::complex<double>> &mat) 
+{
+    std::vector<std::complex<long double>> matx(mat.begin(), mat.end());
+    std::complex<long double> perm = perm_BBFG(matx);
+    return static_cast<std::complex<double>>(perm);
 }
 
 }

--- a/tests/libwalrus_unittest.cpp
+++ b/tests/libwalrus_unittest.cpp
@@ -138,7 +138,7 @@ TEST(PermanentRealBBFG, Random) {
                     mat[2] * mat[3] * mat[7] + mat[0] * mat[5] * mat[7] +
                     mat[1] * mat[3] * mat[8] + mat[0] * mat[4] * mat[8];
 
-  EXPECT_NEAR(expected, libwalrus::perm_BBFG(mat), tol);
+  EXPECT_NEAR(expected, libwalrus::perm_BBFG_qp(mat), tol);
 }
 
 

--- a/tests/libwalrus_unittest.cpp
+++ b/tests/libwalrus_unittest.cpp
@@ -110,6 +110,64 @@ TEST(PermanentComplex, Random) {
   EXPECT_NEAR(std::imag(expected), std::imag(perm), tol);
 }
 
+TEST(PermanentRealBBFG, CompleteGraph) {
+  std::vector<double> mat2(4, 1.0);
+  std::vector<double> mat3(9, 1.0);
+  std::vector<double> mat4(16, 1.0);
+
+  EXPECT_NEAR(2, libwalrus::perm_BBFG_qp(mat2), tol);
+  EXPECT_NEAR(6, libwalrus::perm_BBFG_qp(mat3), tol);
+  EXPECT_NEAR(24, libwalrus::perm_BBFG_qp(mat4), tol);
+}
+
+TEST(PermanentRealBBFG, Random) {
+  std::vector<double> mat(9, 1.0);
+
+  std::default_random_engine generator;
+  generator.seed(20);
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      double randnum = distribution(generator);
+      mat[i * 3 + j] = randnum;
+    }
+  }
+
+  double expected = mat[2] * mat[4] * mat[6] + mat[1] * mat[5] * mat[6] +
+                    mat[2] * mat[3] * mat[7] + mat[0] * mat[5] * mat[7] +
+                    mat[1] * mat[3] * mat[8] + mat[0] * mat[4] * mat[8];
+
+  EXPECT_NEAR(expected, libwalrus::perm_BBFG(mat), tol);
+}
+
+
+TEST(PermanentComplexBBFG, Random) {
+  std::vector<std::complex<double>> mat(9, 1.0);
+
+  std::default_random_engine generator;
+  generator.seed(20);
+  std::normal_distribution<double> distribution(0.0, 1.0);
+
+  for (int i = 0; i < 3; i++) {
+    for (int j = 0; j < 3; j++) {
+      double randnum1 = distribution(generator);
+      double randnum2 = distribution(generator);
+      mat[i * 3 + j] = std::complex<double>(randnum1, randnum2);
+    }
+  }
+
+  std::complex<double> expected =
+      mat[2] * mat[4] * mat[6] + mat[1] * mat[5] * mat[6] +
+      mat[2] * mat[3] * mat[7] + mat[0] * mat[5] * mat[7] +
+      mat[1] * mat[3] * mat[8] + mat[0] * mat[4] * mat[8];
+
+  std::complex<double> perm = libwalrus::perm_BBFG_cmplx(mat);
+
+  EXPECT_NEAR(std::real(expected), std::real(perm), tol);
+  EXPECT_NEAR(std::imag(expected), std::imag(perm), tol);
+}
+
 }  // namespace permanent
 
 namespace recursive_real {

--- a/thewalrus/__init__.py
+++ b/thewalrus/__init__.py
@@ -119,7 +119,7 @@ from ._hafnian import (
 
 from ._low_rank_haf import low_rank_hafnian
 from ._hermite_multidimensional import hafnian_batched, hermite_multidimensional
-from ._permanent import perm, perm_complex, perm_real, permanent_repeated, perm_BBFG, perm_BBFG_real, perm_BBFG_complex
+from ._permanent import perm, perm_complex, perm_real, permanent_repeated, perm_BBFG_real, perm_BBFG_complex
 from ._torontonian import tor, threshold_detection_prob_displacement, threshold_detection_prob, numba_tor
 from ._version import __version__
 

--- a/thewalrus/__init__.py
+++ b/thewalrus/__init__.py
@@ -119,7 +119,7 @@ from ._hafnian import (
 
 from ._low_rank_haf import low_rank_hafnian
 from ._hermite_multidimensional import hafnian_batched, hermite_multidimensional
-from ._permanent import perm, perm_complex, perm_real, permanent_repeated, perm_BBFG_real, perm_BBFG_complex
+from ._permanent import perm, perm_complex, perm_real, permanent_repeated, perm_BBFG, perm_BBFG_real, perm_BBFG_complex
 from ._torontonian import tor, threshold_detection_prob_displacement, threshold_detection_prob, numba_tor
 from ._version import __version__
 

--- a/thewalrus/__init__.py
+++ b/thewalrus/__init__.py
@@ -119,7 +119,7 @@ from ._hafnian import (
 
 from ._low_rank_haf import low_rank_hafnian
 from ._hermite_multidimensional import hafnian_batched, hermite_multidimensional
-from ._permanent import perm, perm_complex, perm_real, permanent_repeated
+from ._permanent import perm, perm_complex, perm_real, permanent_repeated, perm_BBFG_real, perm_BBFG_complex
 from ._torontonian import tor, threshold_detection_prob_displacement, threshold_detection_prob, numba_tor
 from ._version import __version__
 

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -66,19 +66,18 @@ def perm(A, quad=True, fsum=False, method="ryser"):
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
 
-    if method in {"ryser", "Ryser", "r"}:
-        if A.dtype == np.complex:
-            if np.any(np.iscomplex(A)):
-                return perm_complex(A, quad=quad)
-            return perm_real(np.float64(A.real), quad=quad, fsum=fsum)
-        return perm_real(A, quad=quad, fsum=fsum)
-    elif method in {"bbfg", "BBFG", "b"}:
+    if method == "bbfg":
         if A.dtype == np.complex:
             if np.any(np.iscomplex(A)):
                 return perm_BBFG_complex(A)
             return perm_BBFG_real(np.float64(A.real))
         return perm_BBFG_real(A)
-    raise ValueError("Input method is not supported.")
+
+    if A.dtype == np.complex:
+        if np.any(np.iscomplex(A)):
+            return perm_complex(A, quad=quad)
+        return perm_real(np.float64(A.real), quad=quad, fsum=fsum)
+    return perm_real(A, quad=quad, fsum=fsum)
 
 def permanent_repeated(A, rpt):
     r"""Calculates the permanent of matrix :math:`A`, where the ith row/column

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -20,9 +20,8 @@ from ._hafnian import hafnian_repeated
 from .libwalrus import perm_complex, perm_real, perm_BBFG_real, perm_BBFG_complex
 
 
-def perm(A, quad=True, fsum=False):
-    """Returns the permanent of a matrix via the
-    `Ryser formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Ryser_formula>`_.
+def perm(A, quad=True, fsum=False, method="ryser"):
+    """Returns the permanent of a matrix using the `method` formula
 
     For more direct control, you may wish to call :func:`perm_real`
     or :func:`perm_complex` directly.
@@ -34,6 +33,10 @@ def perm(A, quad=True, fsum=False):
         fsum (bool): Whether to use the ``fsum`` method for higher accuracy summation.
             Note that if ``fsum`` is true, double precision will be used, and the
             ``quad`` keyword argument will be ignored.
+        method (string): "ryser" calls the associated methods to 
+        `Ryser formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Ryser_formula>`_,
+        and "bbfg" calls the associated methods to 
+        `BBFG formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Balasubramanian%E2%80%93Bax%E2%80%93Franklin%E2%80%93Glynn_formula>`_.
 
     Returns:
         np.float64 or np.complex128: the permanent of matrix A.
@@ -63,59 +66,23 @@ def perm(A, quad=True, fsum=False):
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
 
-    if A.dtype == np.complex:
-        if np.any(np.iscomplex(A)):
-            return perm_complex(A, quad=quad)
-        return perm_real(np.float64(A.real), quad=quad, fsum=fsum)
+    if method in {"ryser", "Ryser", "r"}:
+        if A.dtype == np.complex:
+            if np.any(np.iscomplex(A)):
+                return perm_complex(A, quad=quad)
+            return perm_real(np.float64(A.real), quad=quad, fsum=fsum)
 
-    return perm_real(A, quad=quad, fsum=fsum)
+        return perm_real(A, quad=quad, fsum=fsum)
+    elif method in {"bbfg", "BBFG", "b"}:
+        if A.dtype == np.complex:
+            if np.any(np.iscomplex(A)):
+                return perm_BBFG_complex(A)
+            return perm_BBFG_real(np.float64(A.real))
 
-
-def perm_BBFG(A):
-    """Returns the permanent of a matrix via the
-    `BBFG formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Balasubramanian%E2%80%93Bax%E2%80%93Franklin%E2%80%93Glynn_formula>`_.
-
-    For more direct control, you may wish to call :func:`perm_BBFG_real`
-    or :func:`perm_BBFG_complex` directly.
-
-    Args:
-        A (array): a square array.
-
-    Returns:
-        np.float64 or np.complex128: the permanent of matrix A.
-    """
-
-    if not isinstance(A, np.ndarray):
-        raise TypeError("Input matrix must be a NumPy array.")
-
-    matshape = A.shape
-
-    if matshape[0] != matshape[1]:
-        raise ValueError("Input matrix must be square.")
-
-    if np.isnan(A).any():
-        raise ValueError("Input matrix must not contain NaNs.")
-
-    if matshape[0] == 2:
-        return A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0]
-
-    if matshape[0] == 3:
-        return (
-            A[0, 2] * A[1, 1] * A[2, 0]
-            + A[0, 1] * A[1, 2] * A[2, 0]
-            + A[0, 2] * A[1, 0] * A[2, 1]
-            + A[0, 0] * A[1, 2] * A[2, 1]
-            + A[0, 1] * A[1, 0] * A[2, 2]
-            + A[0, 0] * A[1, 1] * A[2, 2]
-        )
-
-    if A.dtype == np.complex:
-        if np.any(np.iscomplex(A)):
-            return perm_BBFG_complex(A)
-        return perm_BBFG_real(np.float64(A.real))
-
-    return perm_BBFG_real(A)
-
+        return perm_BBFG_real(A) 
+    else:
+        raise ValueError("Input method is not supported.")
+            
 def permanent_repeated(A, rpt):
     r"""Calculates the permanent of matrix :math:`A`, where the ith row/column
     of :math:`A` is repeated :math:`rpt_i` times.

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -20,7 +20,7 @@ from ._hafnian import hafnian_repeated
 from .libwalrus import perm_complex, perm_real, perm_BBFG_real, perm_BBFG_complex
 
 
-def perm(A, quad=True, fsum=False, method="ryser"):
+def perm(A, quad=True, fsum=False, method="bbfg"):
     """Returns the permanent of a matrix using the `method` formula
 
     For more direct control, you may wish to call :func:`perm_real`

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -17,7 +17,7 @@ Permanent Python interface
 import numpy as np
 
 from ._hafnian import hafnian_repeated
-from .libwalrus import perm_complex, perm_real
+from .libwalrus import perm_complex, perm_real, perm_complex, perm_BBFG_real, perm_BBFG_complex
 
 
 def perm(A, quad=True, fsum=False):

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -33,10 +33,10 @@ def perm(A, quad=True, fsum=False, method="ryser"):
         fsum (bool): Whether to use the ``fsum`` method for higher accuracy summation.
             Note that if ``fsum`` is true, double precision will be used, and the
             ``quad`` keyword argument will be ignored.
-        method (string): "ryser" calls the associated methods to 
-        `Ryser formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Ryser_formula>`_,
-        and "bbfg" calls the associated methods to 
-        `BBFG formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Balasubramanian%E2%80%93Bax%E2%80%93Franklin%E2%80%93Glynn_formula>`_.
+        method (string): "ryser" calls the associated methods to
+            `Ryser formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Ryser_formula>`_,
+            and "bbfg" calls the associated methods to
+            `BBFG formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Balasubramanian%E2%80%93Bax%E2%80%93Franklin%E2%80%93Glynn_formula>`_.
 
     Returns:
         np.float64 or np.complex128: the permanent of matrix A.
@@ -71,18 +71,15 @@ def perm(A, quad=True, fsum=False, method="ryser"):
             if np.any(np.iscomplex(A)):
                 return perm_complex(A, quad=quad)
             return perm_real(np.float64(A.real), quad=quad, fsum=fsum)
-
         return perm_real(A, quad=quad, fsum=fsum)
     elif method in {"bbfg", "BBFG", "b"}:
         if A.dtype == np.complex:
             if np.any(np.iscomplex(A)):
                 return perm_BBFG_complex(A)
             return perm_BBFG_real(np.float64(A.real))
+        return perm_BBFG_real(A)
+    raise ValueError("Input method is not supported.")
 
-        return perm_BBFG_real(A) 
-    else:
-        raise ValueError("Input method is not supported.")
-            
 def permanent_repeated(A, rpt):
     r"""Calculates the permanent of matrix :math:`A`, where the ith row/column
     of :math:`A` is repeated :math:`rpt_i` times.

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -17,7 +17,7 @@ Permanent Python interface
 import numpy as np
 
 from ._hafnian import hafnian_repeated
-from .libwalrus import perm_complex, perm_real, perm_complex, perm_BBFG_real, perm_BBFG_complex
+from .libwalrus import perm_complex, perm_real, perm_BBFG_real, perm_BBFG_complex
 
 
 def perm(A, quad=True, fsum=False):

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -71,6 +71,51 @@ def perm(A, quad=True, fsum=False):
     return perm_real(A, quad=quad, fsum=fsum)
 
 
+def perm_BBFG(A):
+    """Returns the permanent of a matrix via the
+    `BBFG formula <https://en.wikipedia.org/wiki/Computing_the_permanent#Balasubramanian%E2%80%93Bax%E2%80%93Franklin%E2%80%93Glynn_formula>`_.
+
+    For more direct control, you may wish to call :func:`perm_BBFG_real`
+    or :func:`perm_BBFG_complex` directly.
+
+    Args:
+        A (array): a square array.
+
+    Returns:
+        np.float64 or np.complex128: the permanent of matrix A.
+    """
+
+    if not isinstance(A, np.ndarray):
+        raise TypeError("Input matrix must be a NumPy array.")
+
+    matshape = A.shape
+
+    if matshape[0] != matshape[1]:
+        raise ValueError("Input matrix must be square.")
+
+    if np.isnan(A).any():
+        raise ValueError("Input matrix must not contain NaNs.")
+
+    if matshape[0] == 2:
+        return A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0]
+
+    if matshape[0] == 3:
+        return (
+            A[0, 2] * A[1, 1] * A[2, 0]
+            + A[0, 1] * A[1, 2] * A[2, 0]
+            + A[0, 2] * A[1, 0] * A[2, 1]
+            + A[0, 0] * A[1, 2] * A[2, 1]
+            + A[0, 1] * A[1, 0] * A[2, 2]
+            + A[0, 0] * A[1, 1] * A[2, 2]
+        )
+
+    if A.dtype == np.complex:
+        if np.any(np.iscomplex(A)):
+            return perm_BBFG_complex(A)
+        return perm_BBFG_real(np.float64(A.real))
+
+    return perm_BBFG_real(A)
+
 def permanent_repeated(A, rpt):
     r"""Calculates the permanent of matrix :math:`A`, where the ith row/column
     of :math:`A` is repeated :math:`rpt_i` times.

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -66,18 +66,13 @@ def perm(A, quad=True, fsum=False, method="ryser"):
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
 
-    if method == "bbfg":
-        if A.dtype == np.complex:
-            if np.any(np.iscomplex(A)):
-                return perm_BBFG_complex(A)
-            return perm_BBFG_real(np.float64(A.real))
-        return perm_BBFG_real(A)
+    isRyser = False if method == "bbfg" else True
 
     if A.dtype == np.complex:
         if np.any(np.iscomplex(A)):
-            return perm_complex(A, quad=quad)
-        return perm_real(np.float64(A.real), quad=quad, fsum=fsum)
-    return perm_real(A, quad=quad, fsum=fsum)
+            return perm_complex(A, quad=quad) if isRyser else perm_BBFG_complex(A)
+        return perm_real(np.float64(A.real), quad=quad, fsum=fsum) if isRyser else perm_BBFG_real(np.float64(A.real))
+    return perm_real(A, quad=quad, fsum=fsum) if isRyser else perm_BBFG_real(A)
 
 def permanent_repeated(A, rpt):
     r"""Calculates the permanent of matrix :math:`A`, where the ith row/column

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -66,7 +66,7 @@ def perm(A, quad=True, fsum=False, method="ryser"):
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
 
-    isRyser = False if method == "bbfg" else True
+    isRyser = bool(method != "bbfg")
 
     if A.dtype == np.complex:
         if np.any(np.iscomplex(A)):

--- a/thewalrus/libwalrus.pyx
+++ b/thewalrus/libwalrus.pyx
@@ -117,6 +117,7 @@ cdef extern from "../include/libwalrus.hpp" namespace "libwalrus":
     T hafnian_recursive[T](vector[T] &mat)
     T loop_hafnian[T](vector[T] &mat)
     T permanent[T](vector[T] &mat)
+    T perm_BBFG[T](vector[T] &mat) 
 
     T hafnian_rpt[T](vector[T] &mat, vector[int] &nud)
     T loop_hafnian_rpt[T](vector[T] &mat, vector[T] &mu, vector[int] &nud)
@@ -125,6 +126,8 @@ cdef extern from "../include/libwalrus.hpp" namespace "libwalrus":
     double complex permanent_quad(vector[double complex] &mat)
     double perm_fsum[T](vector[T] &mat)
     double permanent_fsum(vector[double] &mat)
+    double perm_BBFG_qp(vector[double] &mat)
+    double complex perm_BBFG_cmplx(vector[double complex] &mat)
 
     double hafnian_recursive_quad(vector[double] &mat)
     double complex hafnian_recursive_quad(vector[double complex] &mat)
@@ -335,7 +338,6 @@ def haf_real(double[:, :] A, bint loop=False, bint recursive=True, quad=True, bi
 # ==============================================================================
 # Permanent
 
-
 def perm_complex(double complex[:, :] A, quad=True):
     """Returns the hafnian of a complex matrix A via the C++ libwalrus library.
 
@@ -359,7 +361,6 @@ def perm_complex(double complex[:, :] A, quad=True):
         return permanent_quad(mat)
 
     return permanent(mat)
-
 
 def perm_real(double [:, :] A, quad=True, fsum=False):
     """Returns the hafnian of a real matrix A via the C++ libwalrus library.
@@ -390,6 +391,45 @@ def perm_real(double [:, :] A, quad=True, fsum=False):
 
     return permanent(mat)
 
+def perm_BBFG_complex(double complex[:, :] A):
+    """Returns the hafnian of a complex matrix A via the C++ libwalrus library
+        using Balasubramanian-Bax-Franklin-Glynn formula.
+
+    Args:
+        A (array): a np.float, square array
+
+    Returns:
+        np.complex128: the hafnian of matrix A
+    """
+    cdef int i, j, n = A.shape[0]
+    cdef vector[double complex] mat
+
+    for i in range(n):
+        for j in range(n):
+            mat.push_back(A[i, j])
+
+    # Exposes a c function to python
+    return perm_BBFG_cmplx(mat)
+
+def perm_BBFG_real(double [:, :] A):
+    """Returns the hafnian of a real matrix A via the C++ libwalrus library
+        using Balasubramanian-Bax-Franklin-Glynn formula.
+
+    Args:
+        A (array): a np.float64, square array
+
+    Returns:
+        np.float64: the hafnian of matrix A
+    """
+    cdef int i, j, n = A.shape[0]
+    cdef vector[double] mat
+
+    for i in range(n):
+        for j in range(n):
+            mat.push_back(A[i, j])
+
+    # Exposes a c function to python
+    return perm_BBFG_qp(mat)
 
 # ==============================================================================
 # Batch hafnian

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -49,7 +49,6 @@ class TestPermanentWrapper:
         assert p == expected
         pp = perm_BBFG(A)
         assert pp == expected
-        
     def test_3x3(self, random_matrix):
         """Check 3x3 permanent"""
         A = random_matrix(3)

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -47,8 +47,7 @@ class TestPermanentWrapper:
         p = perm(A)
         expected = (A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0])
         assert p == expected
-
-        pp = perm_BBFG(A);
+        pp = perm_BBFG(A)
         assert pp == expected
         
     def test_3x3(self, random_matrix):
@@ -64,32 +63,25 @@ class TestPermanentWrapper:
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
         assert p == expected
-        
-        pp = perm_BBFG(A);
+        pp = perm_BBFG(A)
         assert pp == expected
 
     @pytest.mark.parametrize("dtype", [np.float64])
     def test_real(self, random_matrix):
-        """Check perm(A) == perm_real(A) and 
-            perm(A) == perm_BBFG_real(A) for 
-            a random real matrix.
-        """
+        """Check perm(A) == perm_real(A) and perm(A) == perm_BBFG_real(A) for a random real matrix."""
         A = random_matrix(6)
         p = perm(A)
         expected = perm_real(A)
         assert p == expected
-
         A = random_matrix(6)
         A = np.array(A, dtype=np.complex128)
         p = perm(A)
         expected = perm_real(np.float64(A.real))
         assert p == expected
-
         A = random_matrix(6)
         p = perm(A)
         expected = perm_BBFG_real(A)
         assert p == expected
-        
         A = random_matrix(6)
         A = np.array(A, dtype=np.complex128)
         p = perm(A)
@@ -98,15 +90,11 @@ class TestPermanentWrapper:
 
     @pytest.mark.parametrize("dtype", [np.complex128])
     def test_complex(self, random_matrix):
-        """Check perm(A) == perm_complex(A) and 
-            perm(A) == perm_BBFG_complex(A) for 
-            a complex .
-        """
+        """Check perm(A) == perm_complex(A) and perm(A) == perm_BBFG_complex(A) for a complex."""
         A = random_matrix(6)
         p = perm(A)
         expected = perm_complex(A)
         assert np.allclose(p, expected)
-
         A = random_matrix(6)
         p = perm(A)
         expected = perm_BBFG_complex(A)
@@ -114,16 +102,11 @@ class TestPermanentWrapper:
 
     @pytest.mark.parametrize("dtype", [np.float64])
     def test_complex_no_imag(self, random_matrix):
-        """Check perm(A) == perm_real(A) and 
-            perm(A) == perm_BBFG_real(A) for 
-            a complex random matrix with zero 
-            imaginary parts.
-        """
+        """Check perm(A) == perm_real(A) and perm(A) == perm_BBFG_real(A) for a complex random matrix with zero imaginary parts."""
         A = np.complex128(random_matrix(6))
         p = perm(A)
         expected = perm_real(A.real)
         assert np.allclose(p, expected)
-
         A = np.complex128(random_matrix(6))
         p = perm(A)
         expected = perm_BBFG_real(A.real)
@@ -137,7 +120,6 @@ class TestPermanentRepeated:
         """Check 2x2 permanent when rpt is all 0"""
         A = np.array([[2, 1], [1, 3]])
         rpt = [0, 0]
-
         res = permanent_repeated(A, rpt)
         assert res == 1.0
 

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -18,7 +18,7 @@ import pytest
 import numpy as np
 from scipy.special import factorial as fac
 
-from thewalrus import perm, perm_real, perm_complex, permanent_repeated
+from thewalrus import perm, perm_real, perm_complex, permanent_repeated, perm_BBFG_real, perm_BBFG_complex
 
 
 class TestPermanentWrapper:
@@ -72,9 +72,20 @@ class TestPermanentWrapper:
         assert p == expected
 
         A = random_matrix(6)
+        p = perm(A)
+        expected = perm_BBFG_real(A)
+        assert p == expected
+
+        A = random_matrix(6)
         A = np.array(A, dtype=np.complex128)
         p = perm(A)
         expected = perm_real(np.float64(A.real))
+        assert p == expected
+        
+        A = random_matrix(6)
+        A = np.array(A, dtype=np.complex128)
+        p = perm(A)
+        expected = perm_BBFG_real(np.float64(A.real))
         assert p == expected
 
     @pytest.mark.parametrize("dtype", [np.complex128])
@@ -86,6 +97,11 @@ class TestPermanentWrapper:
         expected = perm_complex(A)
         assert np.allclose(p, expected)
 
+        A = random_matrix(6)
+        p = perm(A)
+        expected = perm_BBFG_complex(A)
+        assert np.allclose(p, expected)
+
     @pytest.mark.parametrize("dtype", [np.float64])
     def test_complex_no_imag(self, random_matrix):
         """Check perm(A)=perm_real(A) for a complex random matrix
@@ -94,6 +110,11 @@ class TestPermanentWrapper:
         A = np.complex128(random_matrix(6))
         p = perm(A)
         expected = perm_real(A.real)
+        assert np.allclose(p, expected)
+
+        A = np.complex128(random_matrix(6))
+        p = perm(A)
+        expected = perm_BBFG_real(A.real)
         assert np.allclose(p, expected)
 
 

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -18,7 +18,7 @@ import pytest
 import numpy as np
 from scipy.special import factorial as fac
 
-from thewalrus import perm, perm_real, perm_complex, permanent_repeated, perm_BBFG_real, perm_BBFG_complex
+from thewalrus import perm, perm_real, perm_complex, permanent_repeated, perm_BBFG, perm_BBFG_real, perm_BBFG_complex
 
 
 class TestPermanentWrapper:
@@ -45,8 +45,12 @@ class TestPermanentWrapper:
         """Check 2x2 permanent"""
         A = random_matrix(2)
         p = perm(A)
-        assert p == A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0]
+        expected = (A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0])
+        assert p == expected
 
+        pp = perm_BBFG(A);
+        assert pp == expected
+        
     def test_3x3(self, random_matrix):
         """Check 3x3 permanent"""
         A = random_matrix(3)
@@ -60,6 +64,9 @@ class TestPermanentWrapper:
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
         assert p == expected
+        
+        pp = perm_BBFG(A);
+        assert pp == expected
 
     @pytest.mark.parametrize("dtype", [np.float64])
     def test_real(self, random_matrix):
@@ -93,7 +100,7 @@ class TestPermanentWrapper:
     def test_complex(self, random_matrix):
         """Check perm(A) == perm_complex(A) and 
             perm(A) == perm_BBFG_complex(A) for 
-            a complex random matrix.
+            a complex .
         """
         A = random_matrix(6)
         p = perm(A)

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -44,15 +44,17 @@ class TestPermanentWrapper:
     def test_2x2(self, random_matrix):
         """Check 2x2 permanent"""
         A = random_matrix(2)
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = (A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0])
         assert p == expected
+
         p = perm(A, method="bbfg")
         assert p == expected
+
     def test_3x3(self, random_matrix):
         """Check 3x3 permanent"""
         A = random_matrix(3)
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = (
             A[0, 2] * A[1, 1] * A[2, 0]
             + A[0, 1] * A[1, 2] * A[2, 0]
@@ -62,6 +64,7 @@ class TestPermanentWrapper:
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
         assert p == expected
+
         p = perm(A, method="bbfg")
         assert p == expected
 
@@ -69,33 +72,37 @@ class TestPermanentWrapper:
     def test_real(self, random_matrix):
         """Check perm(A) == perm_real(A) and perm(A, method="bbfg") == perm_BBFG_real(A) for a random real matrix."""
         A = random_matrix(6)
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = perm_real(A)
-        assert p == expected
+        assert np.allclose(p, expected)
+
         A = random_matrix(6)
         A = np.array(A, dtype=np.complex128)
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = perm_real(np.float64(A.real))
-        assert p == expected
+        assert np.allclose(p, expected)
+
         A = random_matrix(6)
         p = perm(A, method="bbfg")
         expected = perm_BBFG_real(A)
-        assert p == expected
+        assert np.allclose(p, expected)
+
         A = random_matrix(6)
         A = np.array(A, dtype=np.complex128)
         p = perm(A, method="bbfg")
         expected = perm_BBFG_real(np.float64(A.real))
-        assert p == expected
+        assert np.allclose(p, expected)
 
     @pytest.mark.parametrize("dtype", [np.complex128])
     def test_complex(self, random_matrix):
         """Check perm(A) == perm_complex(A) and perm(A) == perm_BBFG_complex(A) for a complex."""
         A = random_matrix(6)
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = perm_complex(A)
         assert np.allclose(p, expected)
+
         A = random_matrix(6)
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = perm_BBFG_complex(A)
         assert np.allclose(p, expected)
 
@@ -103,11 +110,12 @@ class TestPermanentWrapper:
     def test_complex_no_imag(self, random_matrix):
         """Check perm(A) == perm_real(A) and perm(A) == perm_BBFG_real(A) for a complex random matrix with zero imaginary parts."""
         A = np.complex128(random_matrix(6))
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = perm_real(A.real)
         assert np.allclose(p, expected)
+
         A = np.complex128(random_matrix(6))
-        p = perm(A)
+        p = perm(A, method="ryser")
         expected = perm_BBFG_real(A.real)
         assert np.allclose(p, expected)
 

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -18,7 +18,7 @@ import pytest
 import numpy as np
 from scipy.special import factorial as fac
 
-from thewalrus import perm, perm_real, perm_complex, permanent_repeated, perm_BBFG, perm_BBFG_real, perm_BBFG_complex
+from thewalrus import perm, perm_real, perm_complex, permanent_repeated, perm_BBFG_real, perm_BBFG_complex
 
 
 class TestPermanentWrapper:
@@ -47,8 +47,8 @@ class TestPermanentWrapper:
         p = perm(A)
         expected = (A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0])
         assert p == expected
-        pp = perm_BBFG(A)
-        assert pp == expected
+        p = perm(A, method="bbfg")
+        assert p == expected
     def test_3x3(self, random_matrix):
         """Check 3x3 permanent"""
         A = random_matrix(3)
@@ -62,12 +62,12 @@ class TestPermanentWrapper:
             + A[0, 0] * A[1, 1] * A[2, 2]
         )
         assert p == expected
-        pp = perm_BBFG(A)
-        assert pp == expected
+        p = perm(A, method="bbfg")
+        assert p == expected
 
     @pytest.mark.parametrize("dtype", [np.float64])
     def test_real(self, random_matrix):
-        """Check perm(A) == perm_real(A) and perm(A) == perm_BBFG_real(A) for a random real matrix."""
+        """Check perm(A) == perm_real(A) and perm(A, method="bbfg") == perm_BBFG_real(A) for a random real matrix."""
         A = random_matrix(6)
         p = perm(A)
         expected = perm_real(A)
@@ -78,12 +78,12 @@ class TestPermanentWrapper:
         expected = perm_real(np.float64(A.real))
         assert p == expected
         A = random_matrix(6)
-        p = perm(A)
+        p = perm(A, method="bbfg")
         expected = perm_BBFG_real(A)
         assert p == expected
         A = random_matrix(6)
         A = np.array(A, dtype=np.complex128)
-        p = perm(A)
+        p = perm(A, method="bbfg")
         expected = perm_BBFG_real(np.float64(A.real))
         assert p == expected
 

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -63,8 +63,9 @@ class TestPermanentWrapper:
 
     @pytest.mark.parametrize("dtype", [np.float64])
     def test_real(self, random_matrix):
-        """Check permanent(A)=perm_real(A) for a random
-        real matrix.
+        """Check perm(A) == perm_real(A) and 
+            perm(A) == perm_BBFG_real(A) for 
+            a random real matrix.
         """
         A = random_matrix(6)
         p = perm(A)
@@ -72,14 +73,14 @@ class TestPermanentWrapper:
         assert p == expected
 
         A = random_matrix(6)
-        p = perm(A)
-        expected = perm_BBFG_real(A)
-        assert p == expected
-
-        A = random_matrix(6)
         A = np.array(A, dtype=np.complex128)
         p = perm(A)
         expected = perm_real(np.float64(A.real))
+        assert p == expected
+
+        A = random_matrix(6)
+        p = perm(A)
+        expected = perm_BBFG_real(A)
         assert p == expected
         
         A = random_matrix(6)
@@ -90,7 +91,9 @@ class TestPermanentWrapper:
 
     @pytest.mark.parametrize("dtype", [np.complex128])
     def test_complex(self, random_matrix):
-        """Check perm(A)=perm_complex(A) for a random matrix.
+        """Check perm(A) == perm_complex(A) and 
+            perm(A) == perm_BBFG_complex(A) for 
+            a complex random matrix.
         """
         A = random_matrix(6)
         p = perm(A)
@@ -104,8 +107,10 @@ class TestPermanentWrapper:
 
     @pytest.mark.parametrize("dtype", [np.float64])
     def test_complex_no_imag(self, random_matrix):
-        """Check perm(A)=perm_real(A) for a complex random matrix
-        with zero imaginary parts.
+        """Check perm(A) == perm_real(A) and 
+            perm(A) == perm_BBFG_real(A) for 
+            a complex random matrix with zero 
+            imaginary parts.
         """
         A = np.complex128(random_matrix(6))
         p = perm(A)


### PR DESCRIPTION
**Context:**
Currently, The Walrus uses the Ryser's formula to calculate permanents of arbitrary matrices that has time-complexity of O(n 2^n) if it's implemented with Gray code ordering. Another useful permanent algorithm with the same complexity is through BBFG's formula that's introduced by David G. Glynn in"The permanent of a square matrix". This pull request adds both C++ and Python support for permanent calculation using the latter formula. 

**Description of the Change:**

- Implemented a **templated** version of the BBFG formula in C++. It's a sequential algorithm (nthreads=1) from "The permanent of a square matrix" by David G. Glynn with using Gray code ordering. This is added in the `./include/permanent.hpp`.
- Added two wrappers for Python integration (`perm_BBFG_qp` and `perm_BBFG_cmplx`) and one for the future parallel vs. serial integration (`perm_BBFG`).
-  Added tests to `./tests/libwalrus_unittest.cpp`
- Integrated algorithms in `./thewalrus/libwalrus.pyx`
- Added tests to `./thewalrus/tests/test_permanent.py` for integrated python methods naming `perm_BBFG`, `perm_BBFG_real` and `perm_BBFG_complex`.
- ... 

**Benefits:**
As @mlxd suggested,  having both methods implemented will allow for performance and accuracy comparisons and trade-offs.

**Possible Drawbacks:**

**Related GitHub Issues:**
Issue #263 created by @mlxd 