### PR TITLE
Fix build failure on M1 Macs

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -32,6 +32,8 @@
 * Corrects bug in the function `photon_number_covar` that gave incorrect results when the covariance between two modes with finite displacements was calculated. 
 [#264](https://github.com/XanaduAI/thewalrus/pull/264)
 
+* Fixes a bug in `setup.py` that would cause the build to fail when using miniforge for M1 macs.
+[#273](https://github.com/XanaduAI/thewalrus/pull/273)
 
 ### Breaking changes
 

--- a/setup.py
+++ b/setup.py
@@ -79,10 +79,6 @@ def build_extensions():
             ("-Xpreprocessor", "-fopenmp", "-mmacosx-version-min=10.9", "-shared")
         )
         config["extra_link_args"].extend(("-Xpreprocessor", "-fopenmp", "-lomp"))
-        #config["include_dirs"].append(
-         #   "/Applications/Xcode.app/Contents/Developer/Toolchains/"
-          #  "XcodeDefault.xctoolchain/usr/include/c++/v1/"
-        #)
     else:
         config["extra_compile_args"].extend(("-fopenmp", "-shared"))
         config["extra_link_args"].extend(("-fopenmp",))

--- a/setup.py
+++ b/setup.py
@@ -79,10 +79,10 @@ def build_extensions():
             ("-Xpreprocessor", "-fopenmp", "-mmacosx-version-min=10.9", "-shared")
         )
         config["extra_link_args"].extend(("-Xpreprocessor", "-fopenmp", "-lomp"))
-        config["include_dirs"].append(
-            "/Applications/Xcode.app/Contents/Developer/Toolchains/"
-            "XcodeDefault.xctoolchain/usr/include/c++/v1/"
-        )
+        #config["include_dirs"].append(
+         #   "/Applications/Xcode.app/Contents/Developer/Toolchains/"
+          #  "XcodeDefault.xctoolchain/usr/include/c++/v1/"
+        #)
     else:
         config["extra_compile_args"].extend(("-fopenmp", "-shared"))
         config["extra_link_args"].extend(("-fopenmp",))


### PR DESCRIPTION
**Context:**
thewalrus will fail to build in a [miniforge](https://github.com/conda-forge/miniforge) environment on M1 Macs. This was caused by the compiler flag that (unnecessarily) included Xcode headers, which resulted in conflicting definitions for certain math functions on M1 Macs if Xcode was installed.

**Description of the Change:**
Removes Xcode include flag

**Benefits:**
thewalrus now compiles in miniforge for M1 Macs.

**Possible Drawbacks:**

**Related GitHub Issues:**
#255 