### PR TITLE
Limit numpy version to 1.20 to prevent numba error about incompatibility with numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.15
+numpy>=1.15,<1.22
 scipy>=1.2.1
 numba>=0.49.1
 pytest>=5.4.1


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
