### PR TITLE
Faster hermite

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New features
 
 ### Improvements
-
+* Faster implementation of `hermite_multidimensional_numba` and `hermite_multidimensional_numba_grad`. [#280](https://github.com/XanaduAI/thewalrus/pull/280)
 ### Bug fixes
 
 * Updates the `samples.generate_torontonian_sample` function to ensure probabilities are normalized. [#250](https://github.com/XanaduAI/thewalrus/pull/250)
@@ -16,7 +16,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Josh Izaac, Nicolas Quesada.
+Josh Izaac, Filippo Miatto, Nicolas Quesada.
 
 ---
 

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -326,7 +326,7 @@ def hafnian_repeated(A, rpt, mu=None, loop=False, rtol=1e-05, atol=1e-08):
     if len(mu) != len(A):
         raise ValueError("Length of means vector must be the same length as the matrix A.")
 
-    if A.dtype == complex or mu.dtype == complex:
+    if complex in (A.dtype, mu.dtype):
         return haf_rpt_complex(A, nud, mu=mu, loop=loop)
 
     return haf_rpt_real(A, nud, mu=mu, loop=loop)

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -190,7 +190,7 @@ def hafnian(
 
         return hafnian_approx(A, num_samples=num_samples)
 
-    if A.dtype == np.complex:
+    if A.dtype == complex:
         # array data is complex type
         if np.any(np.iscomplex(A)):
             # array values contain non-zero imaginary parts
@@ -326,7 +326,7 @@ def hafnian_repeated(A, rpt, mu=None, loop=False, rtol=1e-05, atol=1e-08):
     if len(mu) != len(A):
         raise ValueError("Length of means vector must be the same length as the matrix A.")
 
-    if A.dtype == np.complex or mu.dtype == np.complex:
+    if A.dtype == complex or mu.dtype == complex:
         return haf_rpt_complex(A, nud, mu=mu, loop=loop)
 
     return haf_rpt_real(A, nud, mu=mu, loop=loop)

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -280,15 +280,16 @@ def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     dG_dC = np.array(array / C).astype(dtype)
     dG_dR = np.zeros(array.shape + R.shape, dtype=dtype)
     dG_dy = np.zeros(array.shape + y.shape, dtype=dtype)
-    return _grad_hermite_multidimensional_numba(R, array, dG_dR, dG_dy, cutoffs, num_indices)
+    dG_dR, dG_dy = _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs, num_indices)
+    return dG_dC, dG_dR, dG_dy
 
 @jit(nopython=True)
-def _grad_hermite_multidimensional_numba(R, array, dG_dR, dG_dy, cutoffs, num_indices):
+def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs, num_indices):
     indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:
         dG_dR, dG_dy = fill_grad_hermite_multidimensional_numba_loop(dG_dR, dG_dy, array, idx, R, y)
-    return dG_dC, dG_dR, dG_dy
+    return dG_dR, dG_dy
 
 @jit(nopython=True)
 def fill_grad_hermite_multidimensional_numba_loop(

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -280,11 +280,11 @@ def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     dG_dC = np.array(array / C).astype(dtype)
     dG_dR = np.zeros(array.shape + R.shape, dtype=dtype)
     dG_dy = np.zeros(array.shape + y.shape, dtype=dtype)
-    dG_dR, dG_dy = _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs, num_indices)
+    dG_dR, dG_dy = _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs)
     return dG_dC, dG_dR, dG_dy
 
 @jit(nopython=True)
-def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs, num_indices):
+def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs):
     indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -213,9 +213,9 @@ def hermite_multidimensional_numba(R, cutoff, y, C=1, dtype=None):
 
 @jit(nopython=True)
 def _hermite_multidimensional_numba(R, y, array):
-    r"""Numba-compiled function to fill an array with the Hermite polynomials. It expects an array 
+    r"""Numba-compiled function to fill an array with the Hermite polynomials. It expects an array
     initialized with zeros everywhere except at index (0,...,0) (i.e. the seed value).
-    
+
     Args:
         R (array[complex]): square matrix parametrizing the Hermite polynomial
         y (vector[complex]): vector argument of the Hermite polynomial
@@ -239,14 +239,13 @@ def _hermite_multidimensional_numba(R, y, array):
     return array
 
 
-def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
+def grad_hermite_multidimensional_numba(array, R, y, C=1, dtype=None):
     # pylint: disable=too-many-arguments
     r"""Calculates the gradients of the renormalized multidimensional Hermite polynomials :math:`C*H_k^{(R)}(y)` with respect to its parameters :math:`C`, :math:`y` and :math:`R`.
 
     Args:
         array (array): the multidimensional Hermite polynomials
         R (array[complex]): square matrix parametrizing the Hermite polynomial
-        cutoff (int or list[int]): maximum sizes of the subindices in the Hermite polynomial
         y (vector[complex]): vector argument of the Hermite polynomial
         C (complex): first value of the Hermite polynomials
         dtype (data type): Specifies the data type used for the calculation
@@ -259,11 +258,6 @@ def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     n, _ = R.shape
     if y.shape[0] != n:
         raise ValueError(f"The matrix R and vector y have incompatible dimensions ({R.shape} vs {y.shape})")
-    num_indices = len(y)
-    if isinstance(cutoff, int):
-        cutoffs = tuple([cutoff] * num_indices)
-    else:
-        cutoffs = tuple(cutoff)
     dG_dC = np.array(array / C).astype(dtype)
     dG_dR = np.zeros(array.shape + R.shape, dtype=dtype)
     dG_dy = np.zeros(array.shape + y.shape, dtype=dtype)

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -14,9 +14,7 @@
 """
 Hermite Multidimensional Python interface
 """
-from itertools import product
 from typing import Tuple, Generator
-from functools import lru_cache
 from numba import jit
 from numba.cpython.unsafe.tuple import tuple_setitem
 import numpy as np

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -219,22 +219,15 @@ def hermite_multidimensional_numba(R, cutoff, y, C=1, dtype=None):
         cutoffs = tuple(cutoff)
     array = np.zeros(cutoffs, dtype=dtype)
     array[(0,) * num_indices] = C
-    # for photons in range(1, sum(cutoffs) - num_indices + 1):
-    #     for idx in partition(photons, cutoffs):
-    # return array
-    return fill_hermite_multidimensional_numba(array, R, y)
-
-@jit(nopython=True)
-def fill_hermite_multidimensional_numba(array, R, y):
-    indices = np.ndindex(array.shape)
+    indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:
-        array = fill_hermite_multidimensional_numba_loop(array, idx, R, y)
+        array = hermite_multidimensional_numba_loop(array, idx, R, y)
     return array
 
 
 @jit(nopython=True)
-def fill_hermite_multidimensional_numba_loop(array, idx, R, y):  # pragma: no cover
+def hermite_multidimensional_numba_loop(array, idx, R, y):  # pragma: no cover
     r"""Calculates the renormalized Hermite multidimensional polynomial for a given index.
     Assumes that the polynomials needed for the calculation are stored in `array`.
 
@@ -287,16 +280,11 @@ def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     dG_dC = np.array(array / C).astype(dtype)
     dG_dR = np.zeros(array.shape + R.shape, dtype=dtype)
     dG_dy = np.zeros(array.shape + y.shape, dtype=dtype)
-    dG_dR, dG_dy = fill_grad_hermite_multidimensional_numba(dG_dR, dG_dy, array, R, y)
-    return dG_dC, dG_dR, dG_dy
-
-@jit(nopython=True)
-def fill_grad_hermite_multidimensional_numba(dG_dR, dG_dy, array, R, y):
-    indices = np.ndindex(array.shape)
+    indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:
         dG_dR, dG_dy = fill_grad_hermite_multidimensional_numba_loop(dG_dR, dG_dy, array, idx, R, y)
-    return dG_dR, dG_dy
+    return dG_dC, dG_dR, dG_dy
 
 @jit(nopython=True)
 def fill_grad_hermite_multidimensional_numba_loop(

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -212,7 +212,7 @@ def hermite_multidimensional_numba(R, cutoff, y, C=1, dtype=None):
     return _hermite_multidimensional_numba(R, y, array)
 
 @jit(nopython=True)
-def _hermite_multidimensional_numba(R, y, array):  #pragma no cover
+def _hermite_multidimensional_numba(R, y, array):  #pragma: no cover
     r"""Numba-compiled function to fill an array with the Hermite polynomials. It expects an array
     initialized with zeros everywhere except at index (0,...,0) (i.e. the seed value).
 
@@ -265,7 +265,7 @@ def grad_hermite_multidimensional_numba(array, R, y, C=1, dtype=None):
     return dG_dC, dG_dR, dG_dy
 
 @jit(nopython=True)
-def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy):  #pragma no cover
+def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy):  #pragma: no cover
     r"""
     Numba-compiled function to fill two arrays (dG_dR, dG_dy) with the gradients of the renormalized multidimensional Hermite polynomials
     with respect to its parameters :math:`R` and :math:`y`. It needs the `array` of the multidimensional Hermite polynomials.

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -220,7 +220,7 @@ def hermite_multidimensional_numba(R, cutoff, y, C=1, dtype=None):
     return _hermite_multidimensional_numba(R, array, y, cutoffs)
 
 @jit(nopython=True)
-def _hermite_multidimensional_numba(R, array, y, cutoffs):
+def _hermite_multidimensional_numba(R, array, y, cutoffs):  # pragma: no cover
     indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:
@@ -268,7 +268,7 @@ def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     return dG_dC, dG_dR, dG_dy
 
 @jit(nopython=True)
-def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs):
+def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy, cutoffs):  # pragma: no cover
     indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -212,7 +212,7 @@ def hermite_multidimensional_numba(R, cutoff, y, C=1, dtype=None):
     return _hermite_multidimensional_numba(R, y, array)
 
 @jit(nopython=True)
-def _hermite_multidimensional_numba(R, y, array):
+def _hermite_multidimensional_numba(R, y, array):  #pragma no cover
     r"""Numba-compiled function to fill an array with the Hermite polynomials. It expects an array
     initialized with zeros everywhere except at index (0,...,0) (i.e. the seed value).
 
@@ -265,7 +265,7 @@ def grad_hermite_multidimensional_numba(array, R, y, C=1, dtype=None):
     return dG_dC, dG_dR, dG_dy
 
 @jit(nopython=True)
-def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy):
+def _grad_hermite_multidimensional_numba(R, y, array, dG_dR, dG_dy):  #pragma no cover
     r"""
     Numba-compiled function to fill two arrays (dG_dR, dG_dy) with the gradients of the renormalized multidimensional Hermite polynomials
     with respect to its parameters :math:`R` and :math:`y`. It needs the `array` of the multidimensional Hermite polynomials.

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -86,7 +86,7 @@ def hermite_multidimensional(
     Rt = np.real_if_close(R)
     yt = np.real_if_close(y)
 
-    if Rt.dtype == np.float and yt.dtype == np.float:
+    if Rt.dtype == float and yt.dtype == float:
         if renorm:
             values = np.array(rhmr(Rt, yt, cutoff))
         else:

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -234,7 +234,7 @@ def _hermite_multidimensional_numba(R, array, y, cutoffs):
             u -= SQRT[ki[l]] * R[i, l] * array[kl]
         array[idx] = u / SQRT[idx[i]]
     return array
-    
+
 
 def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     # pylint: disable=too-many-arguments

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -217,12 +217,15 @@ def hermite_multidimensional_numba(R, cutoff, y, C=1, dtype=None):
         cutoffs = tuple(cutoff)
     array = np.zeros(cutoffs, dtype=dtype)
     array[(0,) * num_indices] = C
+    return _hermite_multidimensional_numba(R, array, y, cutoffs, num_indices)
+
+@jit(nopython=True)
+def _hermite_multidimensional_numba(R, array, y, cutoffs, num_indices):
     indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:
         array = hermite_multidimensional_numba_loop(array, idx, R, y)
     return array
-
 
 @jit(nopython=True)
 def hermite_multidimensional_numba_loop(array, idx, R, y):  # pragma: no cover
@@ -248,7 +251,6 @@ def hermite_multidimensional_numba_loop(array, idx, R, y):  # pragma: no cover
         u -= SQRT[ki[l]] * R[i, l] * array[kl]
     array[idx] = u / SQRT[idx[i]]
     return array
-
 
 def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     # pylint: disable=too-many-arguments
@@ -278,6 +280,10 @@ def grad_hermite_multidimensional_numba(array, R, cutoff, y, C=1, dtype=None):
     dG_dC = np.array(array / C).astype(dtype)
     dG_dR = np.zeros(array.shape + R.shape, dtype=dtype)
     dG_dy = np.zeros(array.shape + y.shape, dtype=dtype)
+    return _grad_hermite_multidimensional_numba(R, array, dG_dR, dG_dy, cutoffs, num_indices)
+
+@jit(nopython=True)
+def _grad_hermite_multidimensional_numba(R, array, dG_dR, dG_dy, cutoffs, num_indices):
     indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -217,10 +217,10 @@ def hermite_multidimensional_numba(R, cutoff, y, C=1, dtype=None):
         cutoffs = tuple(cutoff)
     array = np.zeros(cutoffs, dtype=dtype)
     array[(0,) * num_indices] = C
-    return _hermite_multidimensional_numba(R, array, y, cutoffs, num_indices)
+    return _hermite_multidimensional_numba(R, array, y, cutoffs)
 
 @jit(nopython=True)
-def _hermite_multidimensional_numba(R, array, y, cutoffs, num_indices):
+def _hermite_multidimensional_numba(R, array, y, cutoffs):
     indices = np.ndindex(cutoffs)
     next(indices)  # skip the first index (0,...,0)
     for idx in indices:

--- a/thewalrus/tests/test_hermite_multidimensional.py
+++ b/thewalrus/tests/test_hermite_multidimensional.py
@@ -170,7 +170,7 @@ def test_grad_hermite_multidimensional_numba_vs_finite_differences(tol):
     C = 0.5
     cutoff = [3, 3, 3, 3]
     gate = hermite_multidimensional_numba(R, cutoff, y, C, dtype=np.complex128)
-    grad_C, grad_R, grad_y = grad_hermite_multidimensional_numba(gate, R, cutoff, y, C, dtype=np.complex128)
+    grad_C, grad_R, grad_y = grad_hermite_multidimensional_numba(gate, R, y, C, dtype=np.complex128)
 
     delta = 0.000001 + 1j * 0.000001
     expected_grad_C = (hermite_multidimensional_numba(R, cutoff, y, C + delta) - hermite_multidimensional_numba(R, cutoff, y, C - delta)) / (2 * delta)
@@ -213,7 +213,7 @@ def test_auto_dtype_multidim_herm_numba():
     R = R.astype('complex128')
     y = y.astype('complex64')
     poly = poly.astype('complex64')
-    grad = grad_hermite_multidimensional_numba(poly, R, cutoff, y, C, dtype=None)
+    grad = grad_hermite_multidimensional_numba(poly, R, y, C, dtype=None)
     assert all(g.dtype == R.dtype for g in grad)
 
 


### PR DESCRIPTION
fully numbified filling of termite multitimensional arrays and gradients. It turns out `np.ndindex` is supported in numba.