### PR TITLE
Incrementing the version number to 0.16.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,16 +1,10 @@
-# Version 0.17.0-dev
-
-### New features
-
-### Improvements
+# Version 0.16.1
 
 ### Bug fixes
 
 * Updates the `samples.generate_torontonian_sample` function to ensure probabilities are normalized. [#250](https://github.com/XanaduAI/thewalrus/pull/250)
 
 * Pins Numba to version `<0.54` to avoid binary imcompatibilities with the 1.21 release of NumPy. [#250](https://github.com/XanaduAI/thewalrus/pull/250)
-
-### Breaking changes
 
 ### Contributors
 

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,13 +21,13 @@
 #define HAFNIAN_VERSION_MAJOR 0
 
 /// The minor version number
-#define HAFNIAN_VERSION_MINOR 17
+#define HAFNIAN_VERSION_MINOR 16
 
 /// The patch number
-#define HAFNIAN_VERSION_PATCH 0
+#define HAFNIAN_VERSION_PATCH 1
 
 /// The complete version number
 #define HAFNIAN_VERSION_CODE (HAFNIAN_VERSION_MAJOR * 10000 + HAFNIAN_VERSION_MINOR * 100 + HAFNIAN_VERSION_PATCH)
 
 /// Version number as string
-#define HAFNIAN_VERSION_STRING "0.17.0"
+#define HAFNIAN_VERSION_STRING "0.16.1"

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.16.1"


### PR DESCRIPTION
Bugfix release for The Walrus.

* Updates the `samples.generate_torontonian_sample` function to ensure probabilities are normalized. [#250](https://github.com/XanaduAI/thewalrus/pull/250)

* Pins Numba to version `<0.54` to avoid binary imcompatibilities with the 1.21 release of NumPy. [#250](https://github.com/XanaduAI/thewalrus/pull/250)

* Faster implementation of `hermite_multidimensional_numba` and `hermite_multidimensional_numba_grad`. [#280](https://github.com/XanaduAI/thewalrus/pull/280)