### PR TITLE
Incrementing the version number to 0.16.2

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,16 +1,13 @@
-# Version 0.17.0-dev
-
-### New features
-
-### Improvements
+# Version 0.16.2
 
 ### Bug fixes
 * `hermite_multidimensional_numba` now can handle a cutoff of type `np.ndarray` with `shape=[]`. [#283](https://github.com/XanaduAI/thewalrus/pull/283)
-### Breaking changes
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Filippo Miatto
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 0.16.2
 
 ### Bug fixes
-* `hermite_multidimensional_numba` now can handle a cutoff of type `np.ndarray` with `shape=[]`. [#283](https://github.com/XanaduAI/thewalrus/pull/283)
+* `hermite_multidimensional_numba` can now handle a cutoff of type `np.ndarray` with `shape=[]`. [#283](https://github.com/XanaduAI/thewalrus/pull/283)
 
 ### Contributors
 

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,13 +21,13 @@
 #define HAFNIAN_VERSION_MAJOR 0
 
 /// The minor version number
-#define HAFNIAN_VERSION_MINOR 17
+#define HAFNIAN_VERSION_MINOR 16
 
 /// The patch number
-#define HAFNIAN_VERSION_PATCH 0
+#define HAFNIAN_VERSION_PATCH 2
 
 /// The complete version number
 #define HAFNIAN_VERSION_CODE (HAFNIAN_VERSION_MAJOR * 10000 + HAFNIAN_VERSION_MINOR * 100 + HAFNIAN_VERSION_PATCH)
 
 /// Version number as string
-#define HAFNIAN_VERSION_STRING "0.17.0"
+#define HAFNIAN_VERSION_STRING "0.16.2"

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.17.0-dev"
+__version__ = "0.16.2"


### PR DESCRIPTION
Includes a single bugfix necessary for the gaussian transformation gate PRs in Strawberry Fields ([#599](https://github.com/XanaduAI/strawberryfields/pull/599) and [#606](https://github.com/XanaduAI/strawberryfields/pull/606)).

* `hermite_multidimensional_numba` now can handle a cutoff of type `np.ndarray` with `shape=[]`