### PR TITLE
Incrementing the version number to 0.17.0-dev (after 0.16.2 bugfix release)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,19 @@
+# Version 0.17.0-dev
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+### Breaking changes
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+---
+
 # Version 0.16.2
 
 ### Bug fixes

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -21,13 +21,13 @@
 #define HAFNIAN_VERSION_MAJOR 0
 
 /// The minor version number
-#define HAFNIAN_VERSION_MINOR 16
+#define HAFNIAN_VERSION_MINOR 17
 
 /// The patch number
-#define HAFNIAN_VERSION_PATCH 2
+#define HAFNIAN_VERSION_PATCH 0
 
 /// The complete version number
 #define HAFNIAN_VERSION_CODE (HAFNIAN_VERSION_MAJOR * 10000 + HAFNIAN_VERSION_MINOR * 100 + HAFNIAN_VERSION_PATCH)
 
 /// Version number as string
-#define HAFNIAN_VERSION_STRING "0.16.2"
+#define HAFNIAN_VERSION_STRING "0.17.0"

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.16.2"
+__version__ = "0.17.0-dev"


### PR DESCRIPTION
Yet another The Walrus has been released (v0.16.2) and it's due to bump it back to 0.17.0-dev!
