### PR TITLE
Remove dependency on repoze.lru Python package

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### New features
 
 ### Improvements
+* Python installation no longer requires [`repoze.lru`](https://pypi.org/project/repoze.lru/). [#293](https://github.com/XanaduAI/thewalrus/pull/293)
 
 ### Bug fixes
 
@@ -11,6 +12,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Mikhail Andrenkov
 
 ---
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,6 @@ cython>=0.20
 numba>=0.49.1
 numpy>=1.9
 sympy>=1.5.1
-repoze.lru>=0.7
 scipy>=1.2.1
 breathe==4.29.0
 Jinja2==2.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ numba>=0.48.0
 pytest>=5.4.1
 flaky>=3.7.0
 sympy>=1.5.1
-repoze.lru>=0.7
 cython
 dask[delayed]

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,6 @@ info = {
         "numba>=0.49.1,<0.54",
         "scipy>=1.2.1",
         "sympy>=1.5.1",
-        "repoze.lru>=0.7",
     ],
     "setup_requires": ["cython", "numpy"],
     "ext_modules": build_extensions(),

--- a/thewalrus/_low_rank_haf.py
+++ b/thewalrus/_low_rank_haf.py
@@ -15,11 +15,11 @@
 Algorithms for hafnians of low-rank matrices.
 """
 
+from functools import lru_cache
 from itertools import product
 import numpy as np
 from sympy import symbols, expand
 from scipy.special import factorial2
-from repoze.lru import lru_cache
 
 
 @lru_cache(maxsize=1000000)


### PR DESCRIPTION
**Context:**
There is a Python installation dependency on [repoze.lru](https://pypi.org/project/repoze.lru/) which uses a license that may be unsuitable for some projects.

**Description of the Change:**
- Removed repoze.lru as a Python dependency; `functools.lru_cache()` is now used in place of `repoze.lru_cache()`.

**Benefits:**
- The Walrus has fewer dependencies.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.