### PR TITLE
do not use __float128 on non-intel platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.arch == 'aarch64'
         uses: docker/setup-qemu-action@v1
         with:
-          platforms: all 
+          platforms: linux/arm64 
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==1.12.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-randomly flaky
       CIBW_TEST_COMMAND: python -m pytest --randomly-seed=137 {project}/thewalrus
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
       CIBW_BUILD_VERBOSITY: 1
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,13 @@ on:
   pull_request:
 
 jobs:
-  linux-wheels-x86-64:
-    name: wheels linux
+  linux-wheels:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        arch: [x86_64]
+        arch: [x86_64, aarch64]
     runs-on: ${{ matrix.os }}
+    name: wheels linux-${{ matrix.arch }}
 
     env:
       CIBW_BUILD: 'cp37-* cp38-* cp39-*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       CIBW_BUILD: 'cp37-* cp38-* cp39-*'
       # Python build settings
       CIBW_BEFORE_BUILD: |
-        pip install numpy==1.19.5 scipy cython
+        pip install numpy scipy cython
       # Testing of built wheels
       CIBW_TEST_REQUIRES: numpy scipy pytest pytest-cov pytest-randomly flaky
       CIBW_TEST_COMMAND: python -m pytest --randomly-seed=137 {project}/thewalrus

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,12 @@ jobs:
         name: Install Python
         with:
           python-version: '3.9'
+      
+      - name: Set up QEMU (aarch64)
+        if: matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all 
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==1.12.0

--- a/include/permanent.hpp
+++ b/include/permanent.hpp
@@ -19,14 +19,20 @@
 
 typedef unsigned long long int ullint;
 typedef long long int llint;
-//typedef long double qp;
 
-#if (defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__) || defined(__INTEL_COMPILER))
+
+/**
+ * Check for compiler support for quad precision floats. Only
+ * GCC on x86 is supported.
+ */
+#if (defined(__GNUC__) || defined(__GNUG__)) && \
+    (defined(__x86_64__) || defined(__i386__)) && \
+    !(defined(__clang__))
 typedef __float128 qp;
-//#include <quadmath.h>
 #else
 typedef long double qp;
 #endif
+
 
 /**
  * Gray code generator.

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,7 @@ info = {
     "provides": ["thewalrus"],
     "install_requires": [
         "dask[delayed]",
-        "numba>=0.49.1,<0.54",
-        "scipy>=1.2.1",
+        "numba>=0.54",
         "sympy>=1.5.1",
     ],
     "setup_requires": ["cython", "numpy"],

--- a/thewalrus/tests/test_hafnian.py
+++ b/thewalrus/tests/test_hafnian.py
@@ -131,6 +131,10 @@ class TestHafnianWrapper:
         haf = hafnian(A)
         expected = haf_real(A)
         assert np.allclose(haf, expected)
+        
+        haf = hafnian(A, loop=True, quad=False)
+        expected = haf_real(A, loop=True)
+        assert np.allclose(haf, expected)
 
         haf = hafnian(A, loop=True)
         expected = haf_real(A, loop=True)


### PR DESCRIPTION
**Context:**
Aliasing of type `__float128` was resulting in build failures on aarch64. This is because the GCC
extension that provides this type is [not available on aarch64.](https://gcc.gnu.org/onlinedocs/gcc/Floating-Types.html)

**Description of the Change:**
Adds a compiler check in `permanent.hpp` to prevent aliasing `__float128` if the platform is not i386 or AMD64. Other platforms will fall back to double precision.

**Benefits:**
Build will succeed on aarch64.

**Possible Drawbacks:**
To keep the compiler check simple, it will exclude certain exotic architectures that do support `__float128`, such as PowerPC. 

**Related GitHub Issues:**
#290 
