### PR TITLE
Upload wheels to S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Upload Wheels
         if: github.ref == 'refs/heads/master'
         run: |
-          pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
+          pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
 
   mac-wheels-x86-64:
@@ -117,7 +117,7 @@ jobs:
       - name: Upload Wheels
         if: github.ref == 'refs/heads/master'
         run: |
-          pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
+          pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
 
   win-wheels:
@@ -167,6 +167,6 @@ jobs:
       - name: Upload Wheels
         if: github.ref == 'refs/heads/master'
         run: |
-          pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
+          pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_BUILD_VERBOSITY: 1
 
+      # wheelhouse uploader
+      WHEELHOUSE_UPLOADER_USERNAME: ${{ secrets.WHEELHOUSE_UPLOADER_USERNAME }}
+      WHEELHOUSE_UPLOADER_SECRET: ${{ secrets.WHEELHOUSE_UPLOADER_SECRET }}
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -46,10 +50,15 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
 
-      - uses: kittaakos/upload-artifact-as-is@v0
-        if: github.ref == 'refs/heads/master'
+      - uses: actions/upload-artifact@v2
         with:
-          path: ./wheelhouse/
+          path: ./wheelhouse/*.whl
+
+      - name: Upload Wheels
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
+          python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
 
   mac-wheels-x86-64:
     name: wheels macos
@@ -74,6 +83,10 @@ jobs:
         python -m pytest --randomly-seed=137 {project}/thewalrus
       CIBW_BUILD_VERBOSITY: 1
 
+      # wheelhouse uploader
+      WHEELHOUSE_UPLOADER_USERNAME: ${{ secrets.WHEELHOUSE_UPLOADER_USERNAME }}
+      WHEELHOUSE_UPLOADER_SECRET: ${{ secrets.WHEELHOUSE_UPLOADER_SECRET }}
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -95,10 +108,15 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: ${{matrix.arch}}
 
-      - uses: kittaakos/upload-artifact-as-is@v0
-        if: github.ref == 'refs/heads/master'
+      - uses: actions/upload-artifact@v2
         with:
-          path: ./wheelhouse/
+          path: ./wheelhouse/*.whl
+
+      - name: Upload Wheels
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
+          python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
 
   win-wheels:
     name: wheels windows
@@ -119,6 +137,10 @@ jobs:
         python -m pytest --randomly-seed=137 {project}/thewalrus
       CIBW_BUILD_VERBOSITY: 1
 
+      # wheelhouse uploader
+      WHEELHOUSE_UPLOADER_USERNAME: ${{ secrets.WHEELHOUSE_UPLOADER_USERNAME }}
+      WHEELHOUSE_UPLOADER_SECRET: ${{ secrets.WHEELHOUSE_UPLOADER_SECRET }}
+
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1
@@ -135,7 +157,12 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
 
-      - uses: kittaakos/upload-artifact-as-is@v0
-        if: github.ref == 'refs/heads/master'
+      - uses: actions/upload-artifact@v2
         with:
-          path: ./wheelhouse/
+          path: ./wheelhouse/*.whl
+
+      - name: Upload Wheels
+        if: github.ref == 'refs/heads/master'
+        run: |
+          pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
+          python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,13 +50,14 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
 
-      - uses: kittaakos/upload-artifact-as-is@v0
-        # if: github.ref == 'refs/heads/master'
+      - name: Upload wheels to github artifacts
+        uses: kittaakos/upload-artifact-as-is@v0
+        if: github.ref == 'refs/heads/master'
         with:
           path: ./wheelhouse/
 
-      - name: Upload Wheels
-        # if: github.ref == 'refs/heads/master'
+      - name: Upload wheels to xanadu-wheels
+        if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
 
@@ -110,13 +111,14 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: ${{matrix.arch}}
 
-      - uses: kittaakos/upload-artifact-as-is@v0
-        # if: github.ref == 'refs/heads/master'
+      - name: Upload wheels to github artifacts
+        uses: kittaakos/upload-artifact-as-is@v0
+        if: github.ref == 'refs/heads/master'
         with:
           path: ./wheelhouse/
 
-      - name: Upload Wheels
-        # if: github.ref == 'refs/heads/master'
+      - name: Upload wheels to xanadu-wheels
+        if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --region us-east-1 --local-folder ./wheelhouse/ xanadu-wheels
@@ -160,13 +162,14 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
 
-      - uses: kittaakos/upload-artifact-as-is@v0
-        # if: github.ref == 'refs/heads/master'
+      - name: Upload wheels to github artifacts
+        uses: kittaakos/upload-artifact-as-is@v0
+        if: github.ref == 'refs/heads/master'
         with:
           path: ./wheelhouse/
 
-      - name: Upload Wheels
-        # # if: github.ref == 'refs/heads/master'
+      - name: Upload wheels to xanadu-wheels
+        if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,3 +166,4 @@ jobs:
         run: |
           pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,12 +51,12 @@ jobs:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
 
       - uses: kittaakos/upload-artifact-as-is@v0
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         with:
           path: ./wheelhouse/
 
       - name: Upload Wheels
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
@@ -110,12 +110,12 @@ jobs:
           CIBW_ARCHS_MACOS: ${{matrix.arch}}
 
       - uses: kittaakos/upload-artifact-as-is@v0
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         with:
           path: ./wheelhouse/
 
       - name: Upload Wheels
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
@@ -160,12 +160,12 @@ jobs:
         uses: pypa/cibuildwheel@v1.12.0
 
       - uses: kittaakos/upload-artifact-as-is@v0
-        if: github.ref == 'refs/heads/master'
+        # if: github.ref == 'refs/heads/master'
         with:
           path: ./wheelhouse/
 
       - name: Upload Wheels
-        if: github.ref == 'refs/heads/master'
+        # # if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
 
-          python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
+          python -m wheelhouse_uploader upload --provider-name S3 --region us-east-1 --local-folder ./wheelhouse/ xanadu-wheels
 
   mac-wheels-x86-64:
     name: wheels macos
@@ -119,7 +119,7 @@ jobs:
         # if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
-          python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
+          python -m wheelhouse_uploader upload --provider-name S3 --region us-east-1 --local-folder ./wheelhouse/ xanadu-wheels
 
   win-wheels:
     name: wheels windows
@@ -170,5 +170,5 @@ jobs:
         run: |
           pip install --user https://github.com/apache/libcloud/archive/refs/tags/v3.4.1.zip wheelhouse-uploader
 
-          python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
+          python -m wheelhouse_uploader upload --provider-name S3 --region us-east-1 --local-folder ./wheelhouse/ xanadu-wheels
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,9 +50,10 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: ${{matrix.arch}}
 
-      - uses: actions/upload-artifact@v2
+      - uses: kittaakos/upload-artifact-as-is@v0
+        if: github.ref == 'refs/heads/master'
         with:
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse/
 
       - name: Upload Wheels
         if: github.ref == 'refs/heads/master'
@@ -108,9 +109,10 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: ${{matrix.arch}}
 
-      - uses: actions/upload-artifact@v2
+      - uses: kittaakos/upload-artifact-as-is@v0
+        if: github.ref == 'refs/heads/master'
         with:
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse/
 
       - name: Upload Wheels
         if: github.ref == 'refs/heads/master'
@@ -157,13 +159,14 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
 
-      - uses: actions/upload-artifact@v2
+      - uses: kittaakos/upload-artifact-as-is@v0
+        if: github.ref == 'refs/heads/master'
         with:
-          path: ./wheelhouse/*.whl
+          path: ./wheelhouse/
 
       - name: Upload Wheels
         if: github.ref == 'refs/heads/master'
         run: |
           pip install --user https://github.com/joerick/libcloud/archive/v1.5.0-s3fix.zip wheelhouse-uploader
           python -m wheelhouse_uploader upload --provider-name S3 --local-folder ./wheelhouse/ xanadu-wheels
-          
+

--- a/thewalrus/tests/test_hafnian_approx.py
+++ b/thewalrus/tests/test_hafnian_approx.py
@@ -54,4 +54,4 @@ def test_ones_approx(n):
     A = np.float64(np.ones([2 * n, 2 * n]))
     haf = hafnian(A, approx=True, num_samples=10000)
     expected = fac(2 * n) / (fac(n) * (2 ** n))
-    assert np.abs(haf - expected) / expected < 0.15
+    assert np.abs(haf - expected) / expected < 0.2


### PR DESCRIPTION
**Context:**
PR #298 configure github actions to upload builds to S3.  The changes from such PR are not successfully uploading the wheels as required due to an SSL error.

**Description of the Change:**
- Update apache libcloud to solve SSL issue

**Benefits:**
Wheels of dev versions of the walrus are available to download on S3

**Possible Drawbacks:**
None

**Related GitHub Issues:**
#292 Port CI to github actions