### PR TITLE
Update libwalrus.pyx

### DIFF
--- a/thewalrus/libwalrus.pyx
+++ b/thewalrus/libwalrus.pyx
@@ -16,9 +16,6 @@
 cimport cython
 cimport numpy as np
 import numpy as np
-from libc.stdlib cimport free
-from cpython cimport PyObject, Py_INCREF
-from libcpp.vector cimport vector
 
 np.import_array()
 


### PR DESCRIPTION
Removes unused imports that where only needed when Hermite polynomials where calculated in C++
