### PR TITLE
Fix size-0 matrix permanents

### DIFF
--- a/.github/ACKNOWLEDGMENTS.md
+++ b/.github/ACKNOWLEDGMENTS.md
@@ -57,3 +57,5 @@
 * [Benjamin Lanthier](https://github.com/benjaminlanthier) (Polytechnique Montréal) :mage: Warlock of eigenvalues
 
 * [Brandon Turcotte](https://github.com/brandonpolymtl) (Polytechnique Montréal) - :star2: The Quantum-plators
+
+* [Gregory Morse](https://github.com/GregoryMorse) (Eötvös Loránd University) - :volcano: Low level code perfector

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,11 +6,15 @@
 
 ### Bug fixes
 
+* Permanent algorithms handle 0x0 cases correctly. [#320](https://github.com/XanaduAI/thewalrus/pull/320)
+
 ### Breaking changes
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Gregory Morse
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,7 +16,6 @@ This release contains contributions from (in alphabetical order):
 
 Gregory Morse
 
-
 ---
 
 # Version 0.18.0

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,6 +16,7 @@ This release contains contributions from (in alphabetical order):
 
 Gregory Morse
 
+
 ---
 
 # Version 0.18.0

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -55,7 +55,7 @@ def perm(A, method="bbfg"):
         raise ValueError("Input matrix must not contain NaNs.")
 
     if matshape[0] == 0:
-        return 1
+        return A.dtype.type(1.0)
 
     if matshape[0] == 1:
         return A[0, 0]
@@ -96,7 +96,7 @@ def perm_ryser(M):  # pragma: no cover
     """
     n = len(M)
     if n == 0:
-        return 1
+        return M.dtype.type(1.0)
     # row_comb keeps the sum of previous subsets.
     # Every iteration, it removes a term and/or adds a new term
     # to give the term to add for the next subset
@@ -141,7 +141,7 @@ def perm_bbfg(M):  # pragma: no cover
 
     n = len(M)
     if n == 0:
-        return 1
+        return M.dtype.type(1.0)
     row_comb = np.sum(M, 0)
     total = 0
     old_gray = 0

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -54,6 +54,8 @@ def perm(A, method="bbfg"):
     if np.isnan(A).any():
         raise ValueError("Input matrix must not contain NaNs.")
 
+    if matshape[0] == 0: return 1
+    if matshape[0] == 1: return A[0, 0]
     if matshape[0] == 2:
         return A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0]
 
@@ -89,6 +91,7 @@ def perm_ryser(M):  # pragma: no cover
         float or complex: the permanent of matrix ``M``
     """
     n = len(M)
+    if n == 0: return 1
     # row_comb keeps the sum of previous subsets.
     # Every iteration, it removes a term and/or adds a new term
     # to give the term to add for the next subset
@@ -132,6 +135,7 @@ def perm_bbfg(M):  # pragma: no cover
     """
 
     n = len(M)
+    if n == 0: return 1
     row_comb = np.sum(M, 0)
     total = 0
     old_gray = 0

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -54,8 +54,12 @@ def perm(A, method="bbfg"):
     if np.isnan(A).any():
         raise ValueError("Input matrix must not contain NaNs.")
 
-    if matshape[0] == 0: return 1
-    if matshape[0] == 1: return A[0, 0]
+    if matshape[0] == 0:
+        return 1
+
+    if matshape[0] == 1:
+        return A[0, 0]
+
     if matshape[0] == 2:
         return A[0, 0] * A[1, 1] + A[0, 1] * A[1, 0]
 
@@ -91,7 +95,8 @@ def perm_ryser(M):  # pragma: no cover
         float or complex: the permanent of matrix ``M``
     """
     n = len(M)
-    if n == 0: return 1
+    if n == 0:
+        return 1
     # row_comb keeps the sum of previous subsets.
     # Every iteration, it removes a term and/or adds a new term
     # to give the term to add for the next subset
@@ -135,7 +140,8 @@ def perm_bbfg(M):  # pragma: no cover
     """
 
     n = len(M)
-    if n == 0: return 1
+    if n == 0:
+        return 1
     row_comb = np.sum(M, 0)
     total = 0
     old_gray = 0

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -45,6 +45,25 @@ class TestPermanentWrapper:
         A = np.array([[2, 1], [1, np.nan]])
         with pytest.raises(ValueError):
             perm(A)
+    
+    def test_0x0(self):
+        """Check 0x0 permanent returns 1"""
+        p = perm(np.zeros((0, 0)), method="ryser")
+        expected = 1
+        assert p == expected
+        
+        p = perm(np.zeros((0, 0)), method="bbfg")
+        assert p == expected
+        
+    def test_1x1(self, random_matrix):
+        """Check 1x1 permanent"""
+        A = random_matrix(1)
+        p = perm(A, method="ryser")
+        expected = A[0, 0]
+        assert p == expected
+        
+        p = perm(A, method="bbfg")
+        assert p == expected
 
     def test_2x2(self, random_matrix):
         """Check 2x2 permanent"""

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -48,16 +48,17 @@ class TestPermanentWrapper:
 
     def test_0x0(self):
         """Check 0x0 permanent returns 1"""
-        p = perm(np.zeros((0, 0)), method="ryser")
+        A = np.zeros((0, 0))
+        p = perm(A, method="ryser")
         expected = 1
         assert p == expected
 
-        p = perm(np.zeros((0, 0)), method="bbfg")
+        p = perm(A, method="bbfg")
         assert p == expected
 
     def test_1x1(self, random_matrix):
         """Check 1x1 permanent"""
-        A = random_matrix(1)
+        A = np.array([[random_matrix(1)]])
         p = perm(A, method="ryser")
         expected = A[0, 0]
         assert p == expected

--- a/thewalrus/tests/test_permanent.py
+++ b/thewalrus/tests/test_permanent.py
@@ -45,23 +45,23 @@ class TestPermanentWrapper:
         A = np.array([[2, 1], [1, np.nan]])
         with pytest.raises(ValueError):
             perm(A)
-    
+
     def test_0x0(self):
         """Check 0x0 permanent returns 1"""
         p = perm(np.zeros((0, 0)), method="ryser")
         expected = 1
         assert p == expected
-        
+
         p = perm(np.zeros((0, 0)), method="bbfg")
         assert p == expected
-        
+
     def test_1x1(self, random_matrix):
         """Check 1x1 permanent"""
         A = random_matrix(1)
         p = perm(A, method="ryser")
         expected = A[0, 0]
         assert p == expected
-        
+
         p = perm(A, method="bbfg")
         assert p == expected
 


### PR DESCRIPTION
**Context:**
Permanent computations with size 0 returning incorrect values, with size 1 not optimized

**Description of the Change:**
Fix 0x0 and optimize 1x1 cases for permanent

**Benefits:**
0x0 matrices have correct output, 1x1 are faster

**Possible Drawbacks:**
None

**Related GitHub Issues:**
#319 