### PR TITLE
Run latest Black version

### DIFF
--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -851,11 +851,11 @@ def hafnian_sparse(A, D=None, loop=False):
     r, _ = np.nonzero(A)
     m = max(Counter(r).values())  # max nonzero values per row/column
 
-    @lru_cache(maxsize=2 ** m)
+    @lru_cache(maxsize=2**m)
     def indices(d, k):
         return d.intersection(set(np.nonzero(A[k])[0]))
 
-    @lru_cache(maxsize=2 ** m)
+    @lru_cache(maxsize=2**m)
     def lhaf(d: frozenset) -> float:
         if not d:
             return 1
@@ -930,7 +930,7 @@ def hafnian_repeated(A, rpt, mu=None, loop=False, rtol=1e-05, atol=1e-08, glynn=
 
     if np.allclose(A, 0, rtol=rtol, atol=atol):
         if loop:
-            return np.prod(mu ** rpt)
+            return np.prod(mu**rpt)
         return 0
 
     if len(mu) != len(A):

--- a/thewalrus/_permanent.py
+++ b/thewalrus/_permanent.py
@@ -104,8 +104,8 @@ def perm_ryser(M):  # pragma: no cover
     total = 0
     old_grey = 0
     sign = +1
-    binary_power_dict = [2 ** i for i in range(n)]
-    num_loops = 2 ** n
+    binary_power_dict = [2**i for i in range(n)]
+    num_loops = 2**n
     for k in range(0, num_loops):
         bin_index = (k + 1) % num_loops
         reduced = np.prod(row_comb)
@@ -146,7 +146,7 @@ def perm_bbfg(M):  # pragma: no cover
     total = 0
     old_gray = 0
     sign = +1
-    binary_power_dict = [2 ** i for i in range(n)]
+    binary_power_dict = [2**i for i in range(n)]
     num_loops = 2 ** (n - 1)
     for bin_index in range(1, num_loops + 1):
         reduced = np.prod(row_comb)

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -61,7 +61,7 @@ def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
     sqrt = np.sqrt(np.arange(cutoff, dtype=dtype))
     mu = np.array([r * np.exp(1j * phi), -r * np.exp(-1j * phi)])
 
-    D[0, 0] = np.exp(-0.5 * r ** 2)
+    D[0, 0] = np.exp(-0.5 * r**2)
     for m in range(1, cutoff):
         D[m, 0] = mu[0] / sqrt[m] * D[m - 1, 0]
 
@@ -171,8 +171,8 @@ def grad_squeezing(T, r, phi):  # pragma: no cover
             grad_r[m, n] = (
                 -0.5 * tanhr * T[m, n]
                 - sechr * tanhr * sqrt[m] * sqrt[n] * T[m - 1, n - 1]
-                - 0.5 * eiphi * sechr ** 2 * sqrt[m] * sqrt[m - 1] * T[m - 2, n]
-                + 0.5 * eiphiconj * sechr ** 2 * sqrt[n] * sqrt[n - 1] * T[m, n - 2]
+                - 0.5 * eiphi * sechr**2 * sqrt[m] * sqrt[m - 1] * T[m - 2, n]
+                + 0.5 * eiphiconj * sechr**2 * sqrt[n] * sqrt[n - 1] * T[m, n - 2]
             )
             grad_phi[m, n] = (
                 -0.5j * eiphi * tanhr * sqrt[m] * sqrt[m - 1] * T[m - 2, n]
@@ -265,7 +265,7 @@ def grad_two_mode_squeezing(T, r, theta):  # pragma: no cover
     # rank 2
     for n in range(1, cutoff):
         grad_r[n, n, 0, 0] = (
-            -tanhr * T[n, n, 0, 0] + sqrt[n] * sqrt[n] * ei * sechr ** 2 * T[n - 1, n - 1, 0, 0]
+            -tanhr * T[n, n, 0, 0] + sqrt[n] * sqrt[n] * ei * sechr**2 * T[n - 1, n - 1, 0, 0]
         )
         grad_theta[n, n, 0, 0] = 1j * ei * tanhr * sqrt[n] * sqrt[n] * T[n - 1, n - 1, 0, 0]
 
@@ -276,7 +276,7 @@ def grad_two_mode_squeezing(T, r, theta):  # pragma: no cover
             if 0 < p < cutoff:
                 grad_r[m, n, p, 0] = (
                     -tanhr * T[m, n, p, 0]
-                    + sqrt[m] * sqrt[n] * ei * sechr ** 2 * T[m - 1, n - 1, p, 0]
+                    + sqrt[m] * sqrt[n] * ei * sechr**2 * T[m - 1, n - 1, p, 0]
                     - tanhr * sechr * sqrt[m] * sqrt[p] * T[m - 1, n, p - 1, 0]
                 )
                 grad_theta[m, n, p, 0] = 1j * ei * tanhr * sqrt[m] * sqrt[n] * T[m - 1, n - 1, p, 0]
@@ -288,10 +288,10 @@ def grad_two_mode_squeezing(T, r, theta):  # pragma: no cover
                 for q in range(cutoff):
                     grad_r[m, n, p, q] = (
                         -tanhr * T[m, n, p, q]
-                        + sqrt[m] * sqrt[n] * ei * sechr ** 2 * T[m - 1, n - 1, p, q]
+                        + sqrt[m] * sqrt[n] * ei * sechr**2 * T[m - 1, n - 1, p, q]
                         - tanhr * sechr * sqrt[m] * sqrt[p] * T[m - 1, n, p - 1, q]
                         - tanhr * sechr * sqrt[n] * sqrt[q] * T[m, n - 1, p, q - 1]
-                        - sqrt[p] * sqrt[q] * eic * sechr ** 2 * T[m, n, p - 1, q - 1]
+                        - sqrt[p] * sqrt[q] * eic * sechr**2 * T[m, n, p - 1, q - 1]
                     )
                     grad_theta[m, n, p, q] = (
                         1j * ei * tanhr * sqrt[m] * sqrt[n] * T[m - 1, n - 1, p, q]

--- a/thewalrus/quantum/adjacency_matrices.py
+++ b/thewalrus/quantum/adjacency_matrices.py
@@ -139,7 +139,7 @@ def adj_scaling(A, n_mean):
                 with respect to x
         """
         vals1 = vals * x
-        dn = (2.0 / x) * np.sum((vals1 / (1 - vals1 ** 2)) ** 2)
+        dn = (2.0 / x) * np.sum((vals1 / (1 - vals1**2)) ** 2)
         return dn
 
     f = lambda x: mean_photon_number(x, ls) - n_mean

--- a/thewalrus/quantum/fock_tensors.py
+++ b/thewalrus/quantum/fock_tensors.py
@@ -304,7 +304,7 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
     if normalize:
         # construct the standard 2D density matrix, and take the trace
         new_ax = np.arange(2 * M).reshape([M, 2]).T.flatten()
-        tr = np.trace(rho.transpose(new_ax).reshape([cutoff ** M, cutoff ** M])).real
+        tr = np.trace(rho.transpose(new_ax).reshape([cutoff**M, cutoff**M])).real
         # renormalize
         rho /= tr
 

--- a/thewalrus/quantum/means_and_variances.py
+++ b/thewalrus/quantum/means_and_variances.py
@@ -109,7 +109,7 @@ def photon_number_covar(mu, cov, j, k, hbar=2):
         mu, cov = reduced_gaussian(mu, cov, [j])
         term_1 = 0.5 * np.trace(cov) ** 2 - np.linalg.det(cov)
         term_2 = mu @ cov @ mu
-        return ((term_1 + term_2) / hbar ** 2) - 0.25
+        return ((term_1 + term_2) / hbar**2) - 0.25
 
     mu, cov = reduced_gaussian(mu, cov, [j, k])
     term_1 = cov[0, 1] ** 2 + cov[0, 3] ** 2 + cov[2, 1] ** 2 + cov[2, 3] ** 2
@@ -120,7 +120,7 @@ def photon_number_covar(mu, cov, j, k, hbar=2):
         + cov[2, 3] * mu[2] * mu[3]
     )
 
-    return (term_1 + 2 * term_2) / (2 * hbar ** 2)
+    return (term_1 + 2 * term_2) / (2 * hbar**2)
 
 
 def photon_number_covmat(mu, cov, hbar=2):
@@ -320,7 +320,7 @@ def _coeff_normal_ordered(m, k):
 
     return sum(
         [
-            (1 / (factorial(mu) * factorial(k - mu))) * ((-1) ** (k - mu) * (mu ** m))
+            (1 / (factorial(mu) * factorial(k - mu))) * ((-1) ** (k - mu) * (mu**m))
             for mu in range(0, k + 1)
         ]
     )

--- a/thewalrus/quantum/photon_number_distributions.py
+++ b/thewalrus/quantum/photon_number_distributions.py
@@ -156,7 +156,7 @@ def characteristic_function(
     if poly_corr is None or poly_corr == 0:
         f = lambda x: 1
     else:
-        f = lambda x: x ** poly_corr
+        f = lambda x: x**poly_corr
 
     if s == 0 or eta == 0:
         return f(0)

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -579,13 +579,13 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
 
     if out_of_bounds is False:
         probabilities = probabilities.flatten() / sum_p
-        vals = np.arange(cutoff ** num_modes, dtype=int)
+        vals = np.arange(cutoff**num_modes, dtype=int)
         return [
             np.unravel_index(np.random.choice(vals, p=probabilities), [cutoff] * num_modes)
             for _ in range(num_samples)
         ]
 
-    upper_limit = cutoff ** num_modes
+    upper_limit = cutoff**num_modes
 
     def sorter(index):
         if index == upper_limit:
@@ -593,7 +593,7 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
 
         return np.unravel_index(index, [cutoff] * num_modes)
 
-    vals = np.arange(1 + cutoff ** num_modes, dtype=int)
+    vals = np.arange(1 + cutoff**num_modes, dtype=int)
     probabilities = np.append(probabilities.flatten(), 1.0 - sum_p)
     return [sorter(np.random.choice(vals, p=probabilities)) for _ in range(num_samples)]
 

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -328,7 +328,7 @@ def mean_photon_number(mu, cov, hbar=2):
         tuple: the photon number expectation and variance
     """
     ex = (np.trace(cov) + mu.T @ mu) / (2 * hbar) - 1 / 2
-    var = (np.trace(cov @ cov) + 2 * mu.T @ cov @ mu) / (2 * hbar ** 2) - 1 / 4
+    var = (np.trace(cov @ cov) + 2 * mu.T @ cov @ mu) / (2 * hbar**2) - 1 / 4
     return ex, var
 
 

--- a/thewalrus/tests/test_hafnian.py
+++ b/thewalrus/tests/test_hafnian.py
@@ -210,7 +210,7 @@ class TestHafnian:
         """Check hafnian(J_2n)=(2n)!/(n!2^n)"""
         A = dtype(np.ones([2 * n, 2 * n]))
         haf = hafnian(A)
-        expected = fac(2 * n) / (fac(n) * (2 ** n))
+        expected = fac(2 * n) / (fac(n) * (2**n))
         assert np.allclose(haf, expected)
 
     @pytest.mark.parametrize("n", [6, 8])

--- a/thewalrus/tests/test_hafnian_approx.py
+++ b/thewalrus/tests/test_hafnian_approx.py
@@ -53,5 +53,5 @@ def test_ones_approx(n):
     """Check hafnian_approx(J_2n)=(2n)!/(n!2^n)"""
     A = np.float64(np.ones([2 * n, 2 * n]))
     haf = hafnian(A, approx=True, num_samples=10000)
-    expected = fac(2 * n) / (fac(n) * (2 ** n))
+    expected = fac(2 * n) / (fac(n) * (2**n))
     assert np.abs(haf - expected) / expected < 0.2

--- a/thewalrus/tests/test_hafnian_repeated.py
+++ b/thewalrus/tests/test_hafnian_repeated.py
@@ -179,7 +179,7 @@ class TestHafnianRepeated:
         A = dtype(np.ones([2 * n, 2 * n]))
         rpt = np.ones([2 * n], dtype=np.int32)
         haf = hafnian_repeated(A, rpt)
-        expected = fac(2 * n) / (fac(n) * (2 ** n))
+        expected = fac(2 * n) / (fac(n) * (2**n))
         assert np.allclose(haf, expected)
 
         A = dtype([[1]])
@@ -226,5 +226,5 @@ class TestHafnianRepeated:
 
         rpt = np.ones([2 * n], dtype=np.int32)
         haf = hafnian_repeated(A, rpt)
-        expected = np.prod(x) * fac(2 * n) / (fac(n) * (2 ** n))
+        expected = np.prod(x) * fac(2 * n) / (fac(n) * (2**n))
         assert np.allclose(haf, expected)

--- a/thewalrus/tests/test_integration.py
+++ b/thewalrus/tests/test_integration.py
@@ -129,19 +129,19 @@ def test_cumulants_three_mode_random_state(hbar):  # pylint: disable=too-many-st
     assert np.allclose(photon_number_cumulant(mu, cov, [1], hbar=hbar), n1_1)
     assert np.allclose(photon_number_cumulant(mu, cov, [2], hbar=hbar), n2_1)
 
-    n0_2 = n ** 2 @ probs0
-    n1_2 = n ** 2 @ probs1
-    n2_2 = n ** 2 @ probs2
-    var0 = n0_2 - n0_1 ** 2
-    var1 = n1_2 - n1_1 ** 2
-    var2 = n2_2 - n2_1 ** 2
+    n0_2 = n**2 @ probs0
+    n1_2 = n**2 @ probs1
+    n2_2 = n**2 @ probs2
+    var0 = n0_2 - n0_1**2
+    var1 = n1_2 - n1_1**2
+    var2 = n2_2 - n2_1**2
     assert np.allclose(photon_number_cumulant(mu, cov, [0, 0], hbar=hbar), var0)
     assert np.allclose(photon_number_cumulant(mu, cov, [1, 1], hbar=hbar), var1)
     assert np.allclose(photon_number_cumulant(mu, cov, [2, 2], hbar=hbar), var2)
 
-    n0_3 = n ** 3 @ probs0 - 3 * n0_2 * n0_1 + 2 * n0_1 ** 3
-    n1_3 = n ** 3 @ probs1 - 3 * n1_2 * n1_1 + 2 * n1_1 ** 3
-    n2_3 = n ** 3 @ probs2 - 3 * n2_2 * n2_1 + 2 * n2_1 ** 3
+    n0_3 = n**3 @ probs0 - 3 * n0_2 * n0_1 + 2 * n0_1**3
+    n1_3 = n**3 @ probs1 - 3 * n1_2 * n1_1 + 2 * n1_1**3
+    n2_3 = n**3 @ probs2 - 3 * n2_2 * n2_1 + 2 * n2_1**3
     assert np.allclose(photon_number_cumulant(mu, cov, [0, 0, 0], hbar=hbar), n0_3)
     assert np.allclose(photon_number_cumulant(mu, cov, [1, 1, 1], hbar=hbar), n1_3)
     assert np.allclose(photon_number_cumulant(mu, cov, [2, 2, 2], hbar=hbar), n2_3)
@@ -162,12 +162,12 @@ def test_cumulants_three_mode_random_state(hbar):  # pylint: disable=too-many-st
     assert np.allclose(photon_number_cumulant(mu, cov, [0, 2], hbar=hbar), covar02)
     assert np.allclose(photon_number_cumulant(mu, cov, [1, 2], hbar=hbar), covar12)
 
-    kappa001 = n ** 2 @ probs01 @ n - 2 * n0n1 * n0_1 - n0_2 * n1_1 + 2 * n0_1 ** 2 * n1_1
-    kappa011 = n @ probs01 @ n ** 2 - 2 * n0n1 * n1_1 - n1_2 * n0_1 + 2 * n1_1 ** 2 * n0_1
-    kappa002 = n ** 2 @ probs02 @ n - 2 * n0n2 * n0_1 - n0_2 * n2_1 + 2 * n0_1 ** 2 * n2_1
-    kappa022 = n @ probs02 @ n ** 2 - 2 * n0n2 * n2_1 - n2_2 * n0_1 + 2 * n2_1 ** 2 * n0_1
-    kappa112 = n ** 2 @ probs12 @ n - 2 * n1n2 * n1_1 - n1_2 * n2_1 + 2 * n1_1 ** 2 * n2_1
-    kappa122 = n @ probs12 @ n ** 2 - 2 * n1n2 * n2_1 - n2_2 * n1_1 + 2 * n2_1 ** 2 * n1_1
+    kappa001 = n**2 @ probs01 @ n - 2 * n0n1 * n0_1 - n0_2 * n1_1 + 2 * n0_1**2 * n1_1
+    kappa011 = n @ probs01 @ n**2 - 2 * n0n1 * n1_1 - n1_2 * n0_1 + 2 * n1_1**2 * n0_1
+    kappa002 = n**2 @ probs02 @ n - 2 * n0n2 * n0_1 - n0_2 * n2_1 + 2 * n0_1**2 * n2_1
+    kappa022 = n @ probs02 @ n**2 - 2 * n0n2 * n2_1 - n2_2 * n0_1 + 2 * n2_1**2 * n0_1
+    kappa112 = n**2 @ probs12 @ n - 2 * n1n2 * n1_1 - n1_2 * n2_1 + 2 * n1_1**2 * n2_1
+    kappa122 = n @ probs12 @ n**2 - 2 * n1n2 * n2_1 - n2_2 * n1_1 + 2 * n2_1**2 * n1_1
 
     assert np.allclose(photon_number_cumulant(mu, cov, [0, 0, 1], hbar=hbar), kappa001)
     assert np.allclose(photon_number_cumulant(mu, cov, [0, 1, 1], hbar=hbar), kappa011)

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -85,7 +85,7 @@ def test_reduced_gaussian(n):
     m = 5
     N = 2 * m
     mu = np.arange(N)
-    cov = np.arange(N ** 2).reshape(N, N)
+    cov = np.arange(N**2).reshape(N, N)
     res = reduced_gaussian(mu, cov, n)
     assert np.all(res[0] == np.array([n, n + m]))
     assert np.all(
@@ -101,7 +101,7 @@ def test_reduced_gaussian_two_mode():
     m = 5
     N = 2 * m
     mu = np.arange(N)
-    cov = np.arange(N ** 2).reshape(N, N)
+    cov = np.arange(N**2).reshape(N, N)
     res = reduced_gaussian(mu, cov, [0, 2])
     assert np.all(res[0] == np.array([0, 2, m, m + 2]))
 
@@ -451,7 +451,7 @@ def test_mean_clicks_adj():
     tr = np.tanh(r)
     A = np.array([[0, tr], [tr, 0]])
     value = _mean_clicks_adj(A)
-    expected = 2 * tr ** 2
+    expected = 2 * tr**2
     assert np.allclose(expected, value)
 
 
@@ -602,7 +602,7 @@ def test_pure_state_amplitude_coherent(i):
     mu = np.array([1.0, 2.0])
     beta = complex_to_real_displacements(mu)
     alpha = beta[0]
-    exact = np.exp(-0.5 * np.abs(alpha) ** 2) * alpha ** i / np.sqrt(np.math.factorial(i))
+    exact = np.exp(-0.5 * np.abs(alpha) ** 2) * alpha**i / np.sqrt(np.math.factorial(i))
     num = pure_state_amplitude(mu, cov, [i])
     assert np.allclose(exact, num)
 
@@ -650,7 +650,7 @@ def test_pure_amplitude_tms_complex_displacement():
     laguerre_part = np.polynomial.Laguerre([0] * n + [1])(
         (alpha + alpha_c * np.tanh(r)) ** 2 / np.tanh(r)
     )
-    exp_part = np.exp(-(alpha * alpha_c + alpha_c ** 2 * np.tanh(r)))
+    exp_part = np.exp(-(alpha * alpha_c + alpha_c**2 * np.tanh(r)))
     amp2 = hyperbolic_pref * laguerre_part * exp_part
     assert np.allclose(amp1, amp2)
 
@@ -743,7 +743,7 @@ def test_state_vector_coherent():
     alpha = beta[0]
     exact = np.array(
         [
-            (np.exp(-0.5 * np.abs(alpha) ** 2) * alpha ** i / np.sqrt(np.math.factorial(i)))
+            (np.exp(-0.5 * np.abs(alpha) ** 2) * alpha**i / np.sqrt(np.math.factorial(i)))
             for i in range(cutoff)
         ]
     )
@@ -1085,7 +1085,7 @@ def test_pnd_two_mode_squeeze_vacuum(tol, r, phi, hbar):
     pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
     n = np.sinh(r) ** 2
     pnd_mean = photon_number_mean_vector(mu, cov, hbar=hbar)
-    assert np.allclose(pnd_cov, np.full((2, 2), n ** 2 + n), atol=tol, rtol=0)
+    assert np.allclose(pnd_cov, np.full((2, 2), n**2 + n), atol=tol, rtol=0)
     assert np.allclose(pnd_mean, np.array([n, n]), atol=tol, rtol=0)
 
 
@@ -1098,7 +1098,7 @@ def test_pnd_thermal(tol, n, N, hbar):
     mu = np.zeros(2 * N)
     pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
     pnd_mean = photon_number_mean_vector(mu, cov, hbar=hbar)
-    assert np.allclose(pnd_cov, np.diag([n ** 2 + n] * N), atol=tol, rtol=0)
+    assert np.allclose(pnd_cov, np.diag([n**2 + n] * N), atol=tol, rtol=0)
     mean_expected = n * np.ones([N])
     assert np.allclose(pnd_mean, mean_expected, atol=tol, rtol=0)
 
@@ -1124,7 +1124,7 @@ def test_pnd_squeeze_displace(tol, r, phi, alpha, hbar):
         + np.sinh(r) ** 4
         + np.sinh(r) ** 2
         + np.abs(alpha) ** 2 * (1 + 2 * np.sinh(r) ** 2)
-        - 2 * np.real(alpha ** 2 * np.exp(-1j * phi) * np.sinh(r) * np.cosh(r))
+        - 2 * np.real(alpha**2 * np.exp(-1j * phi) * np.sinh(r) * np.cosh(r))
     )
 
     mean_analytic = np.abs(alpha) ** 2 + np.sinh(r) ** 2
@@ -1145,10 +1145,10 @@ def test_photon_number_covmat_random_state(hbar):
     n1 = np.sum(probs, axis=0) @ n
     n0 = np.sum(probs, axis=1) @ n
     covar = n0n1 - n0 * n1
-    n12 = np.sum(probs, axis=0) @ (n ** 2)
-    n02 = np.sum(probs, axis=1) @ (n ** 2)
-    varn0 = n02 - n0 ** 2
-    varn1 = n12 - n1 ** 2
+    n12 = np.sum(probs, axis=0) @ (n**2)
+    n02 = np.sum(probs, axis=1) @ (n**2)
+    varn0 = n02 - n0**2
+    varn1 = n12 - n1**2
     expected = np.array([[varn0, covar], [covar, varn1]])
     Ncov = photon_number_covmat(mu, cov, hbar=hbar)
     assert np.allclose(expected, Ncov)
@@ -1434,7 +1434,7 @@ def test_single_mode_displaced_squeezed(r, phi, x, y):
     means = real_to_complex_displacements(beta, hbar=hbar)
     a = alpha
     adxa = np.abs(alpha) ** 2 + np.sinh(r) ** 2
-    a2 = alpha ** 2 - np.exp(1j * phi) * 0.5 * np.sinh(2 * r)
+    a2 = alpha**2 - np.exp(1j * phi) * 0.5 * np.sinh(2 * r)
     patterns = [[0, 0], [1, 1], [0, 1], [1, 0], [0, 2], [2, 0]]
     expected = [1, adxa, a, np.conj(a), a2, np.conj(a2)]
 
@@ -1625,7 +1625,7 @@ def test_total_photon_number_distribution_moments(s, k, eta):
     """Test that the total photon number distribution has the correct mean and variance"""
     expectation_n = characteristic_function(s=s, k=k, eta=eta, poly_corr=1, mu=0)
     expectation_n2 = characteristic_function(s=s, k=k, eta=eta, poly_corr=2, mu=0)
-    var_n = expectation_n2 - expectation_n ** 2
+    var_n = expectation_n2 - expectation_n**2
     expected_n = eta * k * np.sinh(s) ** 2
     expected_var = expected_n * (1 + eta * (1 + 2 * np.sinh(s) ** 2))
     assert np.allclose(expectation_n, expected_n)
@@ -1672,7 +1672,7 @@ def test_photon_number_moment_all_thermal(hbar):
     """Test that photon_number_moment function gives the correct result for a product of thermal states"""
     M = 3
     N = np.random.rand(M)
-    N2 = 2 * N ** 2 + N
+    N2 = 2 * N**2 + N
     cov = 0.5 * hbar * np.diag(np.concatenate([2 * N + 1, 2 * N + 1]))
     mu = np.zeros([2 * M])
     order = 1
@@ -1718,12 +1718,12 @@ def test_photon_number_moment_two_mode_squeezed(r, theta, hbar):
     # Check expected squared photon numbers in each mode
     ind = {0: 2}
     nbar = np.sinh(r) ** 2
-    assert np.allclose(2 * nbar ** 2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
+    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
     ind = {1: 2}
-    assert np.allclose(2 * nbar ** 2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
+    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
     # Check expected value of the product of the photon numbers
     ind = {0: 1, 1: 1}
-    assert np.allclose(2 * nbar ** 2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
+    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
 
 
 @pytest.mark.parametrize("r", [0.5, 0.7, 2])

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -231,7 +231,7 @@ class TestPassiveTransformation:
         """Test that an transformation returns the correct state"""
 
         M = 4
-        cov = np.arange(4 * M ** 2, dtype=np.float64).reshape((2 * M, 2 * M))
+        cov = np.arange(4 * M**2, dtype=np.float64).reshape((2 * M, 2 * M))
         mu = np.arange(2 * M, dtype=np.float64)
 
         T = np.sqrt(0.9) * M ** (-0.5) * np.ones((6, M), dtype=np.float64)
@@ -262,7 +262,7 @@ class TestPassiveTransformation:
     @pytest.mark.parametrize("M", range(1, 10))
     def test_valid_cov(self, M, tol):
         """test that the output is a valid covariance matrix, even when not square"""
-        a = np.arange(4 * M ** 2, dtype=np.float64).reshape((2 * M, 2 * M))
+        a = np.arange(4 * M**2, dtype=np.float64).reshape((2 * M, 2 * M))
         cov = a @ a.T + np.eye(2 * M)
         mu = np.arange(2 * M, dtype=np.float64)
 
@@ -280,7 +280,7 @@ class TestPassiveTransformation:
         test that the outputs agree with the interferometer class when
         transformation is unitary
         """
-        a = np.arange(4 * M ** 2, dtype=np.float64).reshape((2 * M, 2 * M))
+        a = np.arange(4 * M**2, dtype=np.float64).reshape((2 * M, 2 * M))
         cov = a @ a.T + np.eye(2 * M)
         mu = np.arange(2 * M, dtype=np.float64)
 
@@ -299,7 +299,7 @@ class TestPassiveTransformation:
         """test that the output is a valid covariance matrix, even when not square"""
 
         M = 4
-        a = np.arange(4 * M ** 2, dtype=np.float64).reshape((2 * M, 2 * M))
+        a = np.arange(4 * M**2, dtype=np.float64).reshape((2 * M, 2 * M))
         cov = a @ a.T + np.eye(2 * M)
         mu = np.arange(2 * M, dtype=np.float64)
 
@@ -590,7 +590,7 @@ class TestMeanPhotonNumber:
         mean_photon, var = symplectic.mean_photon_number(mu, cov, hbar=hbar)
 
         mean_ex = np.abs(a) ** 2 + nbar
-        var_ex = nbar ** 2 + nbar + np.abs(a) ** 2 * (1 + 2 * nbar)
+        var_ex = nbar**2 + nbar + np.abs(a) ** 2 * (1 + 2 * nbar)
 
         assert np.allclose(mean_photon, mean_ex, atol=tol, rtol=0)
         assert np.allclose(var, var_ex, atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**
Black has been updated to v22.1.0 which changes the way the power operators should be styled:

`a ** b` should now be formatted as `a**b`.

**Description of the Change:**
All spaces around the power operator are removed (along with at least one other minor change).

**Benefits:**
The formatting check now passes with the latest version of Black.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
