### PR TITLE
Sc 14550 distinguishable squeezer functions

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version 0.19.0-dev
 
 ### New features
+* New functions for calculating properties of distinguihable squeezed states of light having passed through an interferometer. [#326](https://github.com/XanaduAI/thewalrus/pull/326)
+
 * New function `ltor` is added which allows `threshold_detector_prob` to act more consistently on displaced and zero-mean Gaussian states. [#317](https://github.com/XanaduAI/thewalrus/pull/317)
 
 * New functions for threshold detection probabilities of Fock states, the Bristolian (brs) and the Unitary Bristolian (ubrs) [#316](https://github.com/XanaduAI/thewalrus/pull/316)

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -44,7 +44,7 @@ def sample(T, rs, n_samples=100, input_cutoff=50):
     p_n = np.array([p / p.sum() for p in p_n])
 
     outputs = np.empty((n_samples, M), dtype=np.int64)
-    for sample in range(n_samples):
+    for samp in range(n_samples):
         output = np.zeros(M, dtype=np.int64)
         for i in range(M):
             n = np.random.choice(np.arange(input_cutoff), p=p_n[i])
@@ -55,7 +55,7 @@ def sample(T, rs, n_samples=100, input_cutoff=50):
                 )
                 output_i = np.bincount(output_modes_i, minlength=M)
                 output += output_i
-        outputs[sample] = output
+        outputs[samp] = output
     return outputs
 
 
@@ -95,4 +95,4 @@ def number_cov(T, rs):
     absT = np.abs(T) ** 2
     covN = (absT * np.sinh(rs) ** 4) @ absT.T
     covM = (absT * (0.5 * np.sinh(2 * rs)) ** 2) @ absT.T
-    return covN + covM + np.diag(distinguishable_number_means(T, rs))
+    return covN + covM + np.diag(number_means(T, rs))

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -50,9 +50,7 @@ def sample(T, rs, n_samples=100, input_cutoff=50):
             n = np.random.choice(np.arange(input_cutoff), p=p_n[i])
             n_detected = np.random.binomial(n, min(1, detection_probs[i]))
             if n_detected > 0:
-                output_modes_i = np.random.choice(
-                    np.arange(M), p=probs[i], size=n_detected
-                )
+                output_modes_i = np.random.choice(np.arange(M), p=probs[i], size=n_detected)
                 output_i = np.bincount(output_modes_i, minlength=M)
                 output += output_i
         outputs[samp] = output
@@ -73,10 +71,7 @@ def number_means(T, rs):
     """
     n = len(rs)
     return np.array(
-        [
-            np.sum([(np.sinh(rs[k]) * np.abs(T[i, k])) ** 2 for k in range(n)])
-            for i in range(n)
-        ]
+        [np.sum([(np.sinh(rs[k]) * np.abs(T[i, k])) ** 2 for k in range(n)]) for i in range(n)]
     )
 
 

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -22,8 +22,8 @@ from .photon_number_distributions import _squeezed_state_distribution
 
 def sample(T, rs, n_samples=100, input_cutoff=50):
     """
-    Calculates a possible resultant photon number distribution when distinguishable
-    squeezers are sent into an interferometer.
+    Calculates a resultant photon number samples when distinguishable squeezers are sent into an
+    interferometer.
 
     Args:
         T (numpy.ndarray): interferometer transmission matrix
@@ -32,7 +32,7 @@ def sample(T, rs, n_samples=100, input_cutoff=50):
         input_cutoff (int): Fock basis photon number cutoff
 
     Returns:
-        outputs (numpy.ndarray): a resultant photon number distribution
+        outputs (numpy.ndarray): resultant samples
     """
     M = T.shape[0]
     abs2T = (T * T.conj()).real
@@ -59,8 +59,8 @@ def sample(T, rs, n_samples=100, input_cutoff=50):
 
 def number_means(T, rs):
     """
-    Calculates the resultant vector of mean photon numbers when distinguishable
-    squeezers are sent into an interferometer.
+    Calculates the resultant vector of mean photon numbers when distinguishable squeezers are sent
+    into an interferometer.
 
     Args:
         T (numpy.ndarray): interferometer transmission matrix
@@ -77,8 +77,8 @@ def number_means(T, rs):
 
 def number_cov(T, rs):
     """
-    Calculates the resultant photon number covariance matrix when distinguishable
-    squeezers are sent into an interferometer.
+    Calculates the resultant photon number covariance matrix when distinguishable squeezers are
+    sent into an interferometer.
 
     Args:
         T (numpy.ndarray): interferometer transmission matrix

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -1,0 +1,98 @@
+# Copyright 2021-2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Functions for calculating properties of states of distinguihable squeezed states of
+light having passed through an interferometer.
+"""
+
+import numpy as np
+from .photon_number_distributions import _squeezed_state_distribution
+
+
+def sample_distinguishable(T, rs, n_samples=100, input_cutoff=50):
+    """
+    Calculates a possible resultant photon number distribution when distinguishable
+    squeezers are sent into an interferometer.
+
+    Args:
+        T (numpy.ndarray): interferometer transmission matrix
+        rs (numpy.ndarray): input squeezing parameters
+        n_samples (int): number of samples to return
+        input_cutoff (int): Fock basis photon number cutoff
+
+    Returns:
+        outputs (numpy.ndarray): a resultant photon number distribution
+    """
+    M = T.shape[0]
+    abs2T = (T * T.conj()).real
+
+    detection_probs = abs2T.sum(0)
+    probs = np.array([abs2T[:, i] / detection_probs[i] for i in range(M)])
+
+    p_n = np.array([_squeezed_state_distribution(r, cutoff=input_cutoff) for r in rs])
+    p_n = np.array([p / p.sum() for p in p_n])
+
+    outputs = np.empty((n_samples, M), dtype=np.int64)
+    for sample in range(n_samples):
+        output = np.zeros(M, dtype=np.int64)
+        for i in range(M):
+            n = np.random.choice(np.arange(input_cutoff), p=p_n[i])
+            n_detected = np.random.binomial(n, min(1, detection_probs[i]))
+            if n_detected > 0:
+                output_modes_i = np.random.choice(
+                    np.arange(M), p=probs[i], size=n_detected
+                )
+                output_i = np.bincount(output_modes_i, minlength=M)
+                output += output_i
+        outputs[sample] = output
+    return outputs
+
+
+def distinguishable_number_means(T, rs):
+    """
+    Calculates the resultant vector of mean photon numbers when distinguishable
+    squeezers are sent into an interferometer.
+
+    Args:
+        T (numpy.ndarray): interferometer transmission matrix
+        rs (numpy.ndarray): input squeezing parameters
+
+    Returns:
+        (numpy.ndarray): resultant mean photon numbers
+    """
+    n = len(r)
+    return np.array(
+        [
+            np.sum([(np.sinh(rs[k]) * np.abs(T[i, k])) ** 2 for k in range(n)])
+            for i in range(n)
+        ]
+    )
+
+
+def distinguishable_number_cov(T, rs):
+    """
+    Calculates the resultant photon number covariance matrix when distinguishable
+    squeezers are sent into an interferometer.
+
+    Args:
+        T (numpy.ndarray): interferometer transmission matrix
+        rs (numpy.ndarray): input squeezing parameters
+
+    Returns:
+        (numpy.ndarray): resultant covariance matrix
+    """
+    absT = np.abs(T) ** 2
+    covN = (absT * np.sinh(rs) ** 4) @ absT.T
+    covM = (absT * (0.5 * np.sinh(2 * rs)) ** 2) @ absT.T
+    return covN + covM + np.diag(distinguishable_number_means(T, rs))

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -20,7 +20,7 @@ import numpy as np
 from .photon_number_distributions import _squeezed_state_distribution
 
 
-def sample_distinguishable(T, rs, n_samples=100, input_cutoff=50):
+def sample(T, rs, n_samples=100, input_cutoff=50):
     """
     Calculates a possible resultant photon number distribution when distinguishable
     squeezers are sent into an interferometer.
@@ -59,7 +59,7 @@ def sample_distinguishable(T, rs, n_samples=100, input_cutoff=50):
     return outputs
 
 
-def distinguishable_number_means(T, rs):
+def number_means(T, rs):
     """
     Calculates the resultant vector of mean photon numbers when distinguishable
     squeezers are sent into an interferometer.
@@ -80,7 +80,7 @@ def distinguishable_number_means(T, rs):
     )
 
 
-def distinguishable_number_cov(T, rs):
+def number_cov(T, rs):
     """
     Calculates the resultant photon number covariance matrix when distinguishable
     squeezers are sent into an interferometer.

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Functions for calculating properties of states of distinguihable squeezed states of
-light having passed through an interferometer.
+Functions for calculating properties of distinguihable squeezed states of light having passed
+through an interferometer.
 """
 
 import numpy as np

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -26,13 +26,13 @@ def sample(T, rs, n_samples=100, input_cutoff=50):
     interferometer.
 
     Args:
-        T (numpy.ndarray): interferometer transmission matrix
-        rs (numpy.ndarray): input squeezing parameters
+        T (array): interferometer transmission matrix
+        rs (array): input squeezing parameters
         n_samples (int): number of samples to return
         input_cutoff (int): Fock basis photon number cutoff
 
     Returns:
-        outputs (numpy.ndarray): resultant samples
+        outputs (array): resultant samples
     """
     M = T.shape[0]
     abs2T = (T * T.conj()).real
@@ -63,11 +63,11 @@ def number_means(T, rs):
     into an interferometer.
 
     Args:
-        T (numpy.ndarray): interferometer transmission matrix
-        rs (numpy.ndarray): input squeezing parameters
+        T (array): interferometer transmission matrix
+        rs (array): input squeezing parameters
 
     Returns:
-        (numpy.ndarray): resultant mean photon numbers
+        (array): resultant mean photon numbers
     """
     n = len(rs)
     return np.array(
@@ -81,11 +81,11 @@ def number_cov(T, rs):
     sent into an interferometer.
 
     Args:
-        T (numpy.ndarray): interferometer transmission matrix
-        rs (numpy.ndarray): input squeezing parameters
+        T (array): interferometer transmission matrix
+        rs (array): input squeezing parameters
 
     Returns:
-        (numpy.ndarray): resultant covariance matrix
+        (array): resultant covariance matrix
     """
     absT = np.abs(T) ** 2
     covN = (absT * np.sinh(rs) ** 4) @ absT.T

--- a/thewalrus/quantum/distinguishable_squeezers.py
+++ b/thewalrus/quantum/distinguishable_squeezers.py
@@ -71,7 +71,7 @@ def distinguishable_number_means(T, rs):
     Returns:
         (numpy.ndarray): resultant mean photon numbers
     """
-    n = len(r)
+    n = len(rs)
     return np.array(
         [
             np.sum([(np.sinh(rs[k]) * np.abs(T[i, k])) ** 2 for k in range(n)])

--- a/thewalrus/tests/test_distinguishable_squeezers.py
+++ b/thewalrus/tests/test_distinguishable_squeezers.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+from scipy.stats import unitary_group
+
+from thewalrus.quantum.distinguishable_squeezers import number_cov, number_means, sample
+
+
+@pytest.mark.parametrize("M", range(2, 8, 2))
+def test_moments_of_distinguishable_distribution(M):
+    T = (unitary_group.rvs(M) * np.random.rand(M)) @ unitary_group.rvs(M)
+    rs = np.random.rand(M)
+    num_samples = 100000
+    samples = sample(rs, T, n_samples=num_samples)
+    means = samples.mean(axis=0)
+    cov = np.cov(samples.T)
+    expected_means = number_means(T, rs)
+    expected_cov = number_cov(T, rs)
+    assert np.allclose(expected_means, means, atol=4 / np.sqrt(num_samples))
+    assert np.allclose(expected_cov, cov, atol=4 / np.sqrt(num_samples))

--- a/thewalrus/tests/test_distinguishable_squeezers.py
+++ b/thewalrus/tests/test_distinguishable_squeezers.py
@@ -1,3 +1,18 @@
+# Copyright 2022 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Distinguishable squeezers tests"""
+
 import numpy as np
 import pytest
 from scipy.stats import unitary_group
@@ -7,6 +22,9 @@ from thewalrus.quantum.distinguishable_squeezers import number_cov, number_means
 
 @pytest.mark.parametrize("M", range(2, 8, 2))
 def test_moments_of_distinguishable_distribution(M):
+    """
+    Test that means and covariance matrices calculated from samples match those calculated directly
+    """
     T = (unitary_group.rvs(M) * np.random.rand(M)) @ unitary_group.rvs(M)
     rs = np.random.rand(M)
     num_samples = 100000

--- a/thewalrus/tests/test_distinguishable_squeezers.py
+++ b/thewalrus/tests/test_distinguishable_squeezers.py
@@ -28,7 +28,7 @@ def test_moments_of_distinguishable_distribution(M):
     T = (unitary_group.rvs(M) * np.random.rand(M)) @ unitary_group.rvs(M)
     rs = np.random.rand(M)
     num_samples = 100000
-    samples = sample(rs, T, n_samples=num_samples)
+    samples = sample(T, rs, n_samples=num_samples)
     means = samples.mean(axis=0)
     cov = np.cov(samples.T)
     expected_means = number_means(T, rs)


### PR DESCRIPTION
**Context:**
Calculations involving distinguishable squeezers can serve as a starting point to compare experiments making use of ostensibly distinguishable squeezers against.

**Description of the Change:**
Adds three methods for calculating output of distinguishable squeezers incident on an interferometer.

**Benefits:**
Can now make calculations of the output of distinguishable squeezers incident on an interferometer.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A

Incidentally, I note that your `pull_request_template.md` refers to `pylint pennylane/path/to/file.py`.