### PR TITLE
Recursive Loop Torontonian for faster computation

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 * Recursive Torontonian added for faster computation based on paper ["Polynomial speedup in Torontonian calculation by a scalable recursive algorithm" by Ágoston Kaposi, Zoltán Kolarovszki, Tamás Kozsik, Zoltán Zimborás, and Péter Rakyta](https://arxiv.org/pdf/2109.04528.pdf). [#321](https://github.com/XanaduAI/thewalrus/pull/321)
 
+* Recursive Loop Torontonian added for faster computation based on combining recursive Torontonian improvement and new loop Torontonian feature [#332](https://github.com/XanaduAI/thewalrus/pull/332)
+
 * Hafnians of odd-sized matrices are calculated roughly twice as fast. [#329](https://github.com/XanaduAI/thewalrus/pull/329)
 
 ### Bug fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 * Recursive Torontonian added for faster computation based on paper ["Polynomial speedup in Torontonian calculation by a scalable recursive algorithm" by Ágoston Kaposi, Zoltán Kolarovszki, Tamás Kozsik, Zoltán Zimborás, and Péter Rakyta](https://arxiv.org/pdf/2109.04528.pdf). [#321](https://github.com/XanaduAI/thewalrus/pull/321)
 
-* Recursive Loop Torontonian added for faster computation based on combining recursive Torontonian improvement and new loop Torontonian feature [#332](https://github.com/XanaduAI/thewalrus/pull/332)
+* Recursive Loop Torontonian added for faster computation based on combining recursive Torontonian improvement and new loop Torontonian feature. [#332](https://github.com/XanaduAI/thewalrus/pull/332)
 
 * Hafnians of odd-sized matrices are calculated roughly twice as fast. [#329](https://github.com/XanaduAI/thewalrus/pull/329)
 

--- a/docs/gbs.rst
+++ b/docs/gbs.rst
@@ -198,13 +198,20 @@ For an :math:`\ell` mode Gaussian state with zero mean, the outcome of threshold
 where :math:`\text{tor}` is the Torontonian. For :math:`2 \ell \times 2 \ell` matrix :math:`\bm{O}` the Torontonian is defined as
 
 .. math::
-	\text{tor}(\bm{O}) = \sum_{S \in P([\ell])} (-1)^{|S|} \frac{1}{\sqrt{\det\left(\mathbb{I} - \bm{O}_{(S)}\right)}}
+	\text{ltor}(\bm{O}) = \sum_{S \in P([\ell])} (-1)^{|S|} \frac{1}{\sqrt{\det\left(\mathbb{I} - \bm{O}_{(S)}\right)}}
 
-The torontonian can be thought of as a generating function for hafnians (cf. the trace algorithm formula in :ref:`algorithms <algorithms>` section). The torontonian algorithm can be specified recursively to improve its performance :cite:`kaposi2021polynomial`
+The torontonian can be thought of as a generating function for hafnians (cf. the trace algorithm formula in :ref:`algorithms <algorithms>` section). The torontonian algorithm can be specified recursively to improve its performance :cite:`kaposi2021polynomial`.
+
+The loop Torontonian is defined as
+
+.. math::
+	\text{ltor}(\bm{O}, \bm{\gamma}) = \sum_{S \in P([\ell])} (-1)^{|S|} \frac{\frac{1}{2} \gamma_{(S)} \det\left(\mathbb{I} - \bm{O}_{(S)}\right)^{-1} \gamma_{(S)}^* }{\sqrt{\det\left(\mathbb{I} - \bm{O}_{(S)}\right)}}
+
+where :math:`\text{ltor}` is the loop Torontonian, and :math:`O=\mathbb{I}-\sigma^{-1}` and `\gamma=(\sigma^{-1}\alpha)^*` where :math:`\alpha` is a :math:`2 \ell \times 2 \ell` vector. 
 
 .. tip::
 
-   The torontonian is implemented as :func:`thewalrus.tor`.
+   The torontonian and loop torontonian are implemented as :func:`thewalrus.tor` and :func:`thewalrus.ltor` respectively.
 
 
 

--- a/docs/gbs.rst
+++ b/docs/gbs.rst
@@ -205,9 +205,9 @@ The torontonian can be thought of as a generating function for hafnians (cf. the
 The loop Torontonian is defined as
 
 .. math::
-	\text{ltor}(\bm{O}, \bm{\gamma}) = \sum_{S \in P([\ell])} (-1)^{|S|} \frac{\frac{1}{2} \gamma_{(S)} \det\left(\mathbb{I} - \bm{O}_{(S)}\right)^{-1} \gamma_{(S)}^* }{\sqrt{\det\left(\mathbb{I} - \bm{O}_{(S)}\right)}}
+	\text{ltor}(\bm{O}, \bm{\gamma}) = \sum_{S \in P([\ell])} (-1)^{|S|} \frac{exp \{\frac{1}{2} \gamma_{(S)} \det\left(\mathbb{I} - \bm{O}_{(S)}\right)^{-1} \gamma_{(S)}^* \}}{\sqrt{\det\left(\mathbb{I} - \bm{O}_{(S)}\right)}}
 
-where :math:`\text{ltor}` is the loop Torontonian, and :math:`O=\mathbb{I}-\sigma^{-1}` and `\gamma=(\sigma^{-1}\alpha)^*` where :math:`\alpha` is a :math:`2 \ell \times 2 \ell` vector. 
+where :math:`\text{ltor}` is the loop Torontonian, and :math:`\gamma=(\Sigma^{-1}\alpha)^*` where :math:`\alpha` is a :math:`2 \ell \times 2 \ell` vector :cite: `bulmer2022threshold`.
 
 .. tip::
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -636,11 +636,9 @@
   year={2021}
 }
 
-@misc{bulmer2022threshold,
-      title={Threshold detection statistics of bosonic states}, 
-      author={Jacob F. F. Bulmer and Stefano Paesani and Rachel S. Chadwick and Nicolás Quesada},
-      year={2022},
-      eprint={2202.04600},
-      archivePrefix={arXiv},
-      primaryClass={quant-ph}
+@article{bulmer2022threshold,
+  title={Threshold detection statistics of bosonic states},
+  author={Bulmer, Jacob FF and Paesani, Stefano and Chadwick, Rachel S and Quesada, Nicol{\'a}s},
+  journal={arXiv preprint arXiv:2202.04600},
+  year={2022}
 }

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -635,3 +635,12 @@
   journal={arXiv preprint arXiv:2109.04528},
   year={2021}
 }
+
+@misc{bulmer2022threshold,
+      title={Threshold detection statistics of bosonic states}, 
+      author={Jacob F. F. Bulmer and Stefano Paesani and Rachel S. Chadwick and Nicolás Quesada},
+      year={2022},
+      eprint={2202.04600},
+      archivePrefix={arXiv},
+      primaryClass={quant-ph}
+}

--- a/thewalrus/__init__.py
+++ b/thewalrus/__init__.py
@@ -130,6 +130,7 @@ from ._torontonian import (
     numba_tor,
     numba_ltor,
     rec_torontonian,
+    rec_ltorontonian,
 )
 from ._version import __version__
 

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -274,7 +274,7 @@ def solve_triangular(L, y):  # pragma: no cover
 
 
 @numba.jit(nopython=True)
-def recursiveLTor_np(L, modes, A, n, gammaL):  # pragma: no cover
+def recursiveLTor(L, modes, A, n, gammaL):  # pragma: no cover
     """Returns the recursive loop Torontonian sub-computation of a matrix
     using numba.
 
@@ -305,14 +305,14 @@ def recursiveLTor_np(L, modes, A, n, gammaL):  # pragma: no cover
         gammaX = gammaL[Z]
         Lsinv = solve_triangular(Ls, gammaX)
         lc = Lsinv.conj().T @ Lsinv
-        tor += ((-1) ** len(nextModes)) * np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(
+        tor += ((-1) ** len(nextModes)) * np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor(
             Ls, nextModes, Az, n, gammaX
         )
     return tor
 
 
 @numba.jit(nopython=True)
-def rec_ltorontonian_np(A, gamma):  # pragma: no cover
+def rec_ltorontonian(A, gamma):  # pragma: no cover
     """Returns the loop Torontonian of a matrix using numba.
 
     Combines algorithm from papers:
@@ -337,7 +337,7 @@ def rec_ltorontonian_np(A, gamma):  # pragma: no cover
     det = np.square(np.prod(np.diag(L)))
     Ls = solve_triangular(L, gamma)
     lc = Ls.conj().T @ Ls
-    return np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(
+    return np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor(
         L, np.empty(0, dtype=np.int_), A, n, gamma
     )
 

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -402,8 +402,13 @@ def numba_ltor(O, gamma):  # pragma: no cover
         I_m_O_XX_inv = np.linalg.inv(I_m_O_XX)
 
         gamma_X = gamma[kept_rows]
-        top = O.dtype.type(np.real(np.exp(0.5 * gamma_X @ I_m_O_XX_inv @ gamma_X.conj())))
-        bottom = np.sqrt(O.dtype.type(np.real(np.linalg.det(I_m_O_XX))))
+        array_type = O.dtype.type
+
+        top_complex = np.exp(0.5 * gamma_X @ I_m_O_XX_inv @ gamma_X.conj())
+        top = array_type(top_complex.real)
+
+        bottom_complex = np.linalg.det(I_m_O_XX)
+        bottom = np.sqrt(array_type(bottom_complex.real))
 
         total += plusminus * top / bottom
 

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -402,13 +402,11 @@ def numba_ltor(O, gamma):  # pragma: no cover
         I_m_O_XX_inv = np.linalg.inv(I_m_O_XX)
 
         gamma_X = gamma[kept_rows]
-        array_type = O.dtype.type
 
-        top_complex = np.exp(0.5 * gamma_X @ I_m_O_XX_inv @ gamma_X.conj())
-        top = array_type(top_complex.real)
+        top = np.exp(0.5 * gamma_X @ I_m_O_XX_inv @ gamma_X.conj())
 
         bottom_complex = np.linalg.det(I_m_O_XX)
-        bottom = np.sqrt(array_type(bottom_complex.real))
+        bottom = np.sqrt(O.dtype.type(bottom_complex.real))
 
         total += plusminus * top / bottom
 

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -148,7 +148,7 @@ def numba_tor(O):  # pragma: no cover
         kept_rows = np.concatenate((kept_modes, kept_modes + N))
         O_XX = nb_ix(O, kept_rows, kept_rows)
 
-        bottom = np.sqrt(np.real(np.linalg.det(I - O_XX) + 0j))
+        bottom = np.sqrt(O.dtype.type(np.real(np.linalg.det(I - O_XX))))
 
         total += plusminus / bottom
 
@@ -183,7 +183,7 @@ def quad_cholesky(L, Z, idx, mat):  # pragma: no cover
         z = 0.0
         for k in range(i):
             z += Ls[i, k] * Ls[i, k].conjugate()
-        Ls[i, i] = np.real(np.sqrt(mat[i, i] - z)) + 0j
+        Ls[i, i] = L.dtype.type(np.real(np.sqrt(mat[i, i] - z)))
     return Ls
 
 
@@ -402,8 +402,8 @@ def numba_ltor(O, gamma):  # pragma: no cover
         I_m_O_XX_inv = np.linalg.inv(I_m_O_XX)
 
         gamma_X = gamma[kept_rows]
-        top = np.exp(0.5 * gamma_X @ I_m_O_XX_inv @ gamma_X.conj())
-        bottom = np.sqrt(np.real(np.linalg.det(I_m_O_XX)) + 0j)
+        top = O.dtype.type(np.real(np.exp(0.5 * gamma_X @ I_m_O_XX_inv @ gamma_X.conj())))
+        bottom = np.sqrt(O.dtype.type(np.real(np.linalg.det(I_m_O_XX))))
 
         total += plusminus * top / bottom
 

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -335,8 +335,8 @@ def rec_ltorontonian(A, gamma):  # pragma: no cover
     Z = np.empty((2 * n,), dtype=np.int_)
     Z[0::2] = np.arange(0, n)
     Z[1::2] = np.arange(n, 2 * n)
-    A = nb_ix(A, Z, Z)
-    gamma = gamma[Z]
+    A = nb_ix(A.astype(np.complex128), Z, Z)
+    gamma = gamma[Z].astype(np.complex128)
     L = np.linalg.cholesky(np.eye(2 * n) - A)
     det = np.square(np.prod(np.diag(L)))
     Ls = solve_triangular(L, gamma)

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -49,7 +49,7 @@ def ltor(A, gamma, recursive=True):
     Args:
         A (array): an NxN array of even dimensions.
         gamma (array): an N-length vector of even dimensions
-        recursive: use the faster recursive implementation.
+        recursive: use the faster recursive implementation
 
     Returns:
         np.float64 or np.complex128: the loop torontonian of matrix A, vector gamma

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -307,7 +307,7 @@ def recursiveLTor(L, modes, A, n, gammaL):  # pragma: no cover
         Ls = quad_cholesky(L, Z, idx, np.eye(2 * nm) - Az)
         det = np.square(np.prod(np.diag(Ls)))
         gammaX = gammaL[Z]
-        Lsinv = solve_triangular(Ls, gammaX)
+        Lsinv = solve_triangular(Ls, gammaX.conj())
         lc = Lsinv.conj().T @ Lsinv
         tot += ((-1) ** len(nextModes)) * np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor(
             Ls, nextModes, Az, n, gammaX
@@ -339,7 +339,7 @@ def rec_ltorontonian(A, gamma):  # pragma: no cover
     gamma = gamma[Z].astype(np.complex128)
     L = np.linalg.cholesky(np.eye(2 * n) - A)
     det = np.square(np.prod(np.diag(L)))
-    Ls = solve_triangular(L, gamma)
+    Ls = solve_triangular(L, gamma.conj())
     lc = Ls.conj().T @ Ls
     return np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor(
         L, np.empty(0, dtype=np.int_), A, n, gamma

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -148,7 +148,7 @@ def numba_tor(O):  # pragma: no cover
         kept_rows = np.concatenate((kept_modes, kept_modes + N))
         O_XX = nb_ix(O, kept_rows, kept_rows)
 
-        bottom = np.sqrt(np.linalg.det(I - O_XX))
+        bottom = np.sqrt(np.real(np.linalg.det(I - O_XX) + 0j))
 
         total += plusminus / bottom
 
@@ -183,7 +183,7 @@ def quad_cholesky(L, Z, idx, mat):  # pragma: no cover
         z = 0.0
         for k in range(i):
             z += Ls[i, k] * Ls[i, k].conjugate()
-        Ls[i, i] = np.sqrt(mat[i, i] - z)
+        Ls[i, i] = np.real(np.sqrt(mat[i, i] - z)) + 0j
     return Ls
 
 
@@ -403,7 +403,7 @@ def numba_ltor(O, gamma):  # pragma: no cover
 
         gamma_X = gamma[kept_rows]
         top = np.exp(0.5 * gamma_X @ I_m_O_XX_inv @ gamma_X.conj())
-        bottom = np.sqrt(np.linalg.det(I_m_O_XX))
+        bottom = np.sqrt(np.real(np.linalg.det(I_m_O_XX)) + 0j)
 
         total += plusminus * top / bottom
 

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -252,7 +252,7 @@ def rec_torontonian(A):  # pragma: no cover
 def solve_triangular(L, y):  # pragma: no cover
     """Returns the solution to the inverse of a lower non-unit
     triangular matrix times a vector like the dtrsv function of
-    LAPACK/BLAS or scipy solve_triangular
+    LAPACK/BLAS or scipy solve_triangular.
 
     Args:
         L (array): invertible triangular matrix

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -249,26 +249,28 @@ def rec_torontonian(A):  # pragma: no cover
 
 @numba.jit(nopython=True)
 def solve_triangular(L, y):  # pragma: no cover
-    """Returns the solution to the inverse of a lower non-unit 
+    """Returns the solution to the inverse of a lower non-unit
     triangular matrix times a vector like the dtrsv function of
     LAPACK/BLAS or scipy solve_triangular
-    
+
     Args:
         L (array): invertible triangular matrix
         y (array): vector
-        
+
     Returns:
         np.float64 or np.complex128: solution of L^(-1)y
     """
     n = len(y)
     x = np.copy(y)
     for j in range(0, n):
-       if x[j] == 0: continue
-       x[j] = x[j] / L[j, j]
-       temp = x[j]
-       for i in range(j + 1, n):
-           x[i] -= temp * L[i, j]
+        if x[j] == 0:
+            continue
+        x[j] = x[j] / L[j, j]
+        temp = x[j]
+        for i in range(j + 1, n):
+            x[i] -= temp * L[i, j]
     return x
+
 
 @numba.jit(nopython=True)
 def recursiveLTor_np(L, modes, A, n, gammaL):  # pragma: no cover
@@ -290,10 +292,10 @@ def recursiveLTor_np(L, modes, A, n, gammaL):  # pragma: no cover
         np.float64 or np.complex128: the recursive loop torontonian
         sub-computation of matrix ``A`` and vector ``gammaL``
     """
-    tor, start = 0., 0 if len(modes) == 0 else modes[-1] + 1
+    tor, start = 0.0, 0 if len(modes) == 0 else modes[-1] + 1
     for i in range(start, n):
         nextModes = np.append(modes, i)
-        nm, idx = len(A) >> 1, (i - len(modes))*2
+        nm, idx = len(A) >> 1, (i - len(modes)) * 2
         Z = np.concatenate((np.arange(idx), np.arange(idx + 2, nm * 2)), axis=0)
         nm -= 1
         Az = numba_ix(A, Z, Z)
@@ -302,8 +304,11 @@ def recursiveLTor_np(L, modes, A, n, gammaL):  # pragma: no cover
         gammaX = gammaL[Z]
         Lsinv = solve_triangular(Ls, gammaX)
         lc = Lsinv.conj().T @ Lsinv
-        tor += ((-1) ** len(nextModes))*np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(Ls, nextModes, Az, n, gammaX)
-  return tor
+        tor += ((-1) ** len(nextModes)) * np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(
+            Ls, nextModes, Az, n, gammaX
+        )
+    return tor
+
 
 @numba.jit(nopython=True)
 def rec_ltorontonian_np(A, gamma):  # pragma: no cover
@@ -322,7 +327,7 @@ def rec_ltorontonian_np(A, gamma):  # pragma: no cover
         and vector ``gamma``
     """
     n = A.shape[0] >> 1
-    Z = np.empty((2*n,), dtype=np.int_)
+    Z = np.empty((2 * n,), dtype=np.int_)
     Z[0::2] = np.arange(0, n)
     Z[1::2] = np.arange(n, 2 * n)
     A = numba_ix(A, Z, Z)
@@ -331,7 +336,10 @@ def rec_ltorontonian_np(A, gamma):  # pragma: no cover
     det = np.square(np.prod(np.diag(L)))
     Ls = solve_triangular(L, gamma)
     lc = Ls.conj().T @ Ls
-    return np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(L, np.empty(0, dtype=np.int_), A, n, gamma)
+    return np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(
+        L, np.empty(0, dtype=np.int_), A, n, gamma
+    )
+
 
 @numba.jit(nopython=True)
 def numba_vac_prob(alpha, sigma):  # pragma: no cover

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -43,12 +43,13 @@ def tor(A, recursive=True):
     return rec_torontonian(A) if recursive else numba_tor(A)
 
 
-def ltor(A, gamma):
+def ltor(A, gamma, recursive=True):
     """Returns the loop Torontonian of an NxN matrix and an N-length vector.
 
     Args:
         A (array): an NxN array of even dimensions.
         gamma (array): an N-length vector of even dimensions
+        recursive: use the faster recursive implementation.
 
     Returns:
         np.float64 or np.complex128: the loop torontonian of matrix A, vector gamma
@@ -71,7 +72,7 @@ def ltor(A, gamma):
     if matshape[0] % 2 != 0:
         raise ValueError("matrix dimension must be even")
 
-    return numba_ltor(A, gamma)
+    return rec_ltorontonian(A, gamma) if recursive else numba_ltor(A, gamma)
 
 
 def threshold_detection_prob(
@@ -246,6 +247,91 @@ def rec_torontonian(A):  # pragma: no cover
     det = np.square(np.prod(np.diag(L)))
     return 1 / np.sqrt(det) + recursiveTor(L, np.empty(0, dtype=np.int_), A, n)
 
+@numba.jit(nopython=True)
+def solve_triangular(L, y):  # pragma: no cover
+    """Returns the solution to the inverse of a lower non-unit 
+    triangular matrix times a vector like the dtrsv function of
+    LAPACK/BLAS or scipy solve_triangular
+    
+    Args:
+        L (array): invertible triangular matrix
+        y (array): vector
+        
+    Returns:
+        np.float64 or np.complex128: solution of L^(-1)y
+    """
+    n = len(y)
+    x = np.copy(y)
+    for j in range(0, n):
+       if x[j] == 0: continue
+       x[j] = x[j] / L[j, j]
+       temp = x[j]
+       for i in range(j + 1, n):
+           x[i] -= temp * L[i, j]
+    return x
+
+@numba.jit(nopython=True)
+def recursiveLTor_np(L, modes, A, n, gammaL):  # pragma: no cover
+    """Returns the recursive loop Torontonian sub-computation of a matrix
+    using numba.
+
+    Combines algorithm from papers:
+    https://arxiv.org/pdf/2109.04528.pdf
+    https://arxiv.org/pdf/2202.04600.pdf
+
+    Args:
+        L (array): current Cholesky
+        modes (array): optical mode
+        A (array): a square, symmetric array of even dimensions
+        n: size of the original matrix
+        gammaL (array): a vector of even dimension
+
+    Returns:
+        np.float64 or np.complex128: the recursive loop torontonian
+        sub-computation of matrix ``A`` and vector ``gammaL``
+    """
+    tor, start = 0., 0 if len(modes) == 0 else modes[-1] + 1
+    for i in range(start, n):
+        nextModes = np.append(modes, i)
+        nm, idx = len(A) >> 1, (i - len(modes))*2
+        Z = np.concatenate((np.arange(idx), np.arange(idx + 2, nm * 2)), axis=0)
+        nm -= 1
+        Az = numba_ix(A, Z, Z)
+        Ls = quad_cholesky_np(L, Z, idx, np.eye(2 * nm) - Az)
+        det = np.square(np.prod(np.diag(Ls)))
+        gammaX = gammaL[Z]
+        Lsinv = solve_triangular(Ls, gammaX)
+        lc = Lsinv.conj().T @ Lsinv
+        tor += ((-1) ** len(nextModes))*np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(Ls, nextModes, Az, n, gammaX)
+  return tor
+
+@numba.jit(nopython=True)
+def rec_ltorontonian_np(A, gamma):  # pragma: no cover
+    """Returns the loop Torontonian of a matrix using numba.
+
+    Combines algorithm from papers:
+    https://arxiv.org/pdf/2109.04528.pdf
+    https://arxiv.org/pdf/2202.04600.pdf
+
+    Args:
+        A (array): a square, symmetric array of even dimensions
+        gamma (array): a vector of even dimension
+
+    Returns:
+        np.float64 or np.complex128: the torontonian of matrix ``A``
+        and vector ``gamma``
+    """
+    n = A.shape[0] >> 1
+    Z = np.empty((2*n,), dtype=np.int_)
+    Z[0::2] = np.arange(0, n)
+    Z[1::2] = np.arange(n, 2 * n)
+    A = numba_ix(A, Z, Z)
+    gamma = gamma[Z]
+    L = np.linalg.cholesky(np.eye(2 * n) - A)
+    det = np.square(np.prod(np.diag(L)))
+    Ls = solve_triangular(L, gamma)
+    lc = Ls.conj().T @ Ls
+    return np.exp(0.5 * lc) / np.sqrt(det) + recursiveLTor_np(L, np.empty(0, dtype=np.int_), A, n, gamma)
 
 @numba.jit(nopython=True)
 def numba_vac_prob(alpha, sigma):  # pragma: no cover

--- a/thewalrus/_torontonian.py
+++ b/thewalrus/_torontonian.py
@@ -247,6 +247,7 @@ def rec_torontonian(A):  # pragma: no cover
     det = np.square(np.prod(np.diag(L)))
     return 1 / np.sqrt(det) + recursiveTor(L, np.empty(0, dtype=np.int_), A, n)
 
+
 @numba.jit(nopython=True)
 def solve_triangular(L, y):  # pragma: no cover
     """Returns the solution to the inverse of a lower non-unit

--- a/thewalrus/tests/test_torontonian.py
+++ b/thewalrus/tests/test_torontonian.py
@@ -261,7 +261,7 @@ def test_probs_sum_to_1(n, scale):
 def test_numba_ltor(N):
     """Tests numba implementations of the loop torontonian against the default
     implementation"""
-    alpha = np.random.random(N)+np.random.random(N)*1j
+    alpha = np.random.random(N) + np.random.random(N) * 1j
     alpha = np.concatenate((alpha, alpha.conj()))
     cov = random_covariance(N)
     O = Xmat(N) @ Amat(cov)

--- a/thewalrus/tests/test_torontonian.py
+++ b/thewalrus/tests/test_torontonian.py
@@ -29,6 +29,7 @@ from thewalrus import (
     numba_tor,
     numba_ltor,
     rec_torontonian,
+    rec_ltorontonian,
 )
 from thewalrus.symplectic import two_mode_squeezing
 from thewalrus._torontonian import numba_vac_prob
@@ -190,10 +191,12 @@ def test_tor_and_threshold_displacement_prob_agree(n_modes):
     expected = tor(O) / np.sqrt(np.linalg.det(Q))
     prob = threshold_detection_prob(mu, cv, np.array([1] * n_modes))
     prob2 = numba_ltor(O, mu) / np.sqrt(np.linalg.det(Q))
-    prob3 = numba_vac_prob(mu, Q) * ltor(O, mu)
+    prob3 = rec_ltorontonian(O, mu) / np.sqrt(np.linalg.det(Q))
+    prob4 = numba_vac_prob(mu, Q) * ltor(O, mu)
     assert np.isclose(expected, prob)
     assert np.isclose(expected, prob2)
     assert np.isclose(expected, prob3)
+    assert np.isclose(expected, prob4)
 
 
 @pytest.mark.parametrize("N", range(1, 10))

--- a/thewalrus/tests/test_torontonian.py
+++ b/thewalrus/tests/test_torontonian.py
@@ -201,12 +201,14 @@ def test_tor_and_threshold_displacement_prob_agree(n_modes):
 
 @pytest.mark.parametrize("N", range(1, 10))
 def test_numba_tor(N):
-    """Tests numba implementation of the torontonian against the default implementation"""
+    """Tests numba implementations of the torontonian against the default implementation"""
     cov = random_covariance(N)
     O = Xmat(N) @ Amat(cov)
     t1 = tor(O)
     t2 = numba_tor(O)
+    t3 = rec_torontonian(O)
     assert np.isclose(t1, t2)
+    assert np.isclose(t1, t3)
 
 
 def test_tor_exceptions():
@@ -256,11 +258,16 @@ def test_probs_sum_to_1(n, scale):
 
 
 @pytest.mark.parametrize("N", range(1, 10))
-def test_recursive_tor(N):
-    """Tests numba implementation of the recursive torontonian against the default
+def test_numba_ltor(N):
+    """Tests numba implementations of the loop torontonian against the default
     implementation"""
+    alpha = np.random.random(N)+np.random.random(N)*1j
+    alpha = np.concatenate((alpha, alpha.conj()))
     cov = random_covariance(N)
     O = Xmat(N) @ Amat(cov)
-    t1 = tor(O)
-    t2 = rec_torontonian(O)
+    mu = O @ alpha
+    t1 = ltor(O, mu)
+    t2 = numba_ltor(O, mu)
+    t3 = ltor_torontonian(O, mu)
     assert np.isclose(t1, t2)
+    assert np.isclose(t1, t3)

--- a/thewalrus/tests/test_torontonian.py
+++ b/thewalrus/tests/test_torontonian.py
@@ -268,6 +268,6 @@ def test_numba_ltor(N):
     mu = O @ alpha
     t1 = ltor(O, mu)
     t2 = numba_ltor(O, mu)
-    t3 = ltor_torontonian(O, mu)
+    t3 = rec_ltorontonian(O, mu)
     assert np.isclose(t1, t2)
     assert np.isclose(t1, t3)


### PR DESCRIPTION
**Context:**

Loop Torontonian computation is less efficient than state of the art.  The improvement is based on discussions with @nquesada and @jakeffbulmer .

**Description of the Change:**

Recursive loop Torontonian is implemented also with numba for optimized code.

Based on loop Torontonian definition: https://arxiv.org/pdf/2202.04600.pdf
Threshold detection statistics of bosonic states
J. F. F. Bulmer, S. Paesani, R. S. Chadwick, and N. Quesada

Combined with paper: https://arxiv.org/pdf/2109.04528.pdf
Polynomial speedup in Torontonian calculation by a
scalable recursive algorithm
Ágoston Kaposi, Zoltán Kolarovszki, Tamás Kozsik, Zoltán Zimborás, and Péter Rakyta

**Benefits:**

Recursive computation gives improvement from n^2.7355*2^n to n^1.0695*2^n, significant improvement in the polynomial time part of the computation.

**Possible Drawbacks:**

None, beyond making the library slightly more complicated by introducing a new default value to use the new faster computation method.

**Related GitHub Issues:**
