### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * New function to check if a matrix is symplectic `is_symplectic`. [#334](https://github.com/XanaduAI/thewalrus/pull/334).
 
+* Adds support for Python 3.10. [#](https://github.com/XanaduAI/thewalrus/pull/)
+
 ### Improvements
 * Update methods for calculating threshold detector probabilties of Gaussian states, now using `ltor` function within `threshold_detection_prob` [#317](https://github.com/XanaduAI/thewalrus/pull/317)
 * `numba_tor` now can benefit from numba parallelisation [#317](https://github.com/XanaduAI/thewalrus/pull/317)
@@ -31,7 +33,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Jake Bulmer, Martin Houde, Fabian Laudenbach, Gregory Morse, Nicolas Quesada
+Jake Bulmer, Martin Houde, Theodor Isacsson, Fabian Laudenbach, Gregory Morse, Nicolas Quesada
 
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -44,19 +44,8 @@ Features
 Installation
 ============
 
-Pre-built binary wheels are available for the following platforms:
-
-+------------+-------------+------------------+---------------+
-|            | macOS 10.6+ | manylinux x86_64 | Windows 64bit |
-+============+=============+==================+===============+
-| Python 3.7 |      X      |        X         |       X       |
-+------------+-------------+------------------+---------------+
-| Python 3.8 |      X      |        X         |       X       |
-+------------+-------------+------------------+---------------+
-| Python 3.9 |      X      |        X         |       X       |
-+------------+-------------+------------------+---------------+
-
-To install, simply run
+The Walrus requires Python version 3.7, 3.8, 3.9, or 3.10. Installation of The Walrus, as
+well as all dependencies, can be done using pip:
 
 .. code-block:: bash
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+pytest==7.1.0
+pytest-randomly==3.11.0
+flaky==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-numpy>=1.19.2
-scipy>=1.2.1
-numba>=0.48.0
-pytest>=5.4.1
-pytest-randomly>=3.5.0
-flaky>=3.7.0
-sympy>=1.5.1
-dask[delayed]
+numpy==1.21.5
+scipy==1.8.0
+numba==0.55.1
+sympy==1.10
+dask[delayed]==2022.2.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ info = {
     "provides": ["thewalrus"],
     "install_requires": [
         "dask[delayed]",
-        "numba>=0.49.1,<0.54",
+        "numba>=0.49.1",
         "scipy>=1.2.1",
         "sympy>=1.5.1",
         "numpy>=1.19.2",
@@ -58,6 +58,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
**Context:**
Python 3.10 is supported by all dependencies.

**Description of the Change:**
Bumps Python support up to 3.10.

**Benefits:**
Python 3.10!

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
