### PR TITLE
Remove redundant Qmat, Amat calls from generate_hafnian_sample

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug fixes
 
+* Remove redundant call of `Qmat`, `Amat` from `generate_hafnian_sample`. [(#343)](https://github.com/XanaduAI/thewalrus/pull/343)
+
 ### Documentation
 
 * The centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)
@@ -17,6 +19,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Antonín Hoskovec
 
 Mikhail Andrenkov
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,9 +20,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Antonín Hoskovec
-
-Mikhail Andrenkov
+Mikhail Andrenkov, Antonín Hoskovec
 
 ---
 

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -117,7 +117,6 @@ def generate_hafnian_sample(
         local_mu = np.zeros(2 * N)
     else:
         local_mu = mean
-    A = Amat(Qmat(cov), hbar=hbar)
 
     for k in range(nmodes):
         probs1 = np.zeros([cutoff + 1], dtype=np.float64)


### PR DESCRIPTION
**Context:**
There is an extra call of the `Qmat` function in the  `generate_hafnian_sample` function. 

**Description of the Change:**
Remove redundant call of `Qmat`, `Amat` from `generate_hafnian_sample`.

**Benefits:**
Removed redundant code

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None