### PR TITLE
Extend single mode symplectic to act on multiple modes 📏

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements
 
+* Added function to extend single mode symplectic to act on multiple modes. [(#347)](https://github.com/XanaduAI/thewalrus/pull/347)
+
 ### Bug fixes
 
 * Remove redundant call of `Qmat`, `Amat` from `generate_hafnian_sample`. [(#343)](https://github.com/XanaduAI/thewalrus/pull/343)

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: docs/requirements.txt
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ nbsphinx==0.7
 numba>=0.49.1
 numpy>=1.9
 sympy>=1.5.1
-scipy>=1.2.1
+scipy>=1.8.0
 Jinja2==2.11.3
 version_information
 sphinx-copybutton

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -57,6 +57,8 @@ Code details
 ------------
 """
 import numpy as np
+from scipy.linalg import block_diag
+from sympy import true
 
 
 def expand(S, modes, N):
@@ -72,7 +74,11 @@ def expand(S, modes, N):
     """
     M = len(S) // 2
     S2 = np.identity(2 * N, dtype=S.dtype)
-    w = np.array(modes)
+    w = np.array([modes]) if isinstance(modes, int) else np.array(modes)
+
+    if M == 1 and w.shape[0] > M:
+        # Extend single-mode gate to repeatedly act on several modes
+        return block_diag(*[S.copy() if mode in w else np.zeros((2,2)) for mode in range(N)])
 
     S2[w.reshape(-1, 1), w.reshape(1, -1)] = S[:M, :M].copy()  # X
     S2[(w + N).reshape(-1, 1), (w + N).reshape(1, -1)] = S[M:, M:].copy()  # P

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -58,7 +58,14 @@ Code details
 """
 import warnings
 import numpy as np
-from scipy.sparse import identity, issparse, coo_array, dia_array, bsr_array, csr_array
+from scipy.sparse import (
+    identity as sparse_identity,
+    issparse,
+    coo_array,
+    dia_array,
+    bsr_array,
+    csr_array,
+)
 
 
 def expand(S, modes, N):
@@ -78,16 +85,16 @@ def expand(S, modes, N):
         array: the resulting :math:`2N\times 2N` Symplectic matrix
     """
     M = S.shape[0] // 2
+    S2 = np.identity(2 * N, dtype=S.dtype)
+
     if issparse(S):
         # cast to sparse matrix that supports slicing and indexing
+        S2 = sparse_identity(2 * N, dtype=S.dtype, format="csr")
         if isinstance(S, (coo_array, dia_array, bsr_array)):
             warnings.warn(
                 "Unsupported sparse matrix type, returning a Compressed Sparse Row (CSR) matrix."
             )
             S = csr_array(S)
-            S2 = identity(2 * N, dtype=S.dtype, format="csr")
-    else:
-        S2 = np.identity(2 * N, dtype=S.dtype)
 
     w = np.array([modes]) if isinstance(modes, int) else np.array(modes)
 

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -58,7 +58,6 @@ Code details
 """
 import numpy as np
 from scipy.linalg import block_diag
-from sympy import true
 
 
 def expand(S, modes, N):
@@ -100,16 +99,14 @@ def extend(S, modes, N):
         array: the resulting :math:`2N\times 2N` Symplectic matrix
     """
     M = len(S) // 2
-
-    if M > 1:
-        raise ValueError(f"`extend` expects a symplectic of size 1, got size {M}.")
-
-    S2 = np.identity(2 * N, dtype=S.dtype)
     w = np.array([modes]) if isinstance(modes, int) else np.array(modes)
 
-    if M == 1 and w.shape[0] > M:
-        # Extend single-mode gate to repeatedly act on several modes
-        return block_diag(*[S.copy() if mode in w else np.zeros((2,2)) for mode in range(N)])
+    if not(M == 1 and w.shape[0] > M):
+        raise ValueError(f"`extend` expects a symplectic of size 1, got size {M}.")
+
+    # Extend single-mode gate to repeatedly act on several modes
+    return block_diag(*[S.copy() if mode in w else np.zeros((2,2)) for mode in range(N)])
+
 
 def expand_vector(alpha, mode, N, hbar=2.0):
     """Returns the phase-space displacement vector associated to a displacement.

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -56,6 +56,7 @@ Gates and operations
 Code details
 ------------
 """
+import warnings
 import numpy as np
 from scipy.sparse import issparse, coo_array, dia_array, bsr_array, csr_array
 
@@ -65,8 +66,11 @@ def expand(S, modes, N):
     If the input is a single mode symplectic, then extends it to act
     on multiple modes.
 
+    Supports scipy sparse matrices. Instances of ``coo_array``, ``dia_array``,
+    ``bsr_array`` will be transformed into `csr_array``.
+
     Args:
-        S (array): a :math:`2M\times 2M` Symplectic matrix
+        S (ndarray or spmatrix): a :math:`2M\times 2M` Symplectic matrix
         modes (Sequence[int]): the list of modes S acts on
         N (int): full size of the subsystem
 
@@ -79,6 +83,9 @@ def expand(S, modes, N):
     if issparse(S):
         # cast to sparse matrix that supports slicing and indexing
         if isinstance(S, (coo_array, dia_array, bsr_array)):
+            warnings.warn(
+                "Unsupported sparse matrix type, returning a Compressed Sparse Row matrix."
+            )
             S = csr_array(S)
         sparse_type = type(S)
         S2 = sparse_type(S2, dtype=S.dtype)

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -84,7 +84,7 @@ def expand(S, modes, N):
         # cast to sparse matrix that supports slicing and indexing
         if isinstance(S, (coo_array, dia_array, bsr_array)):
             warnings.warn(
-                "Unsupported sparse matrix type, returning a Compressed Sparse Row matrix."
+                "Unsupported sparse matrix type, returning a Compressed Sparse Row (CSR) matrix."
             )
             S = csr_array(S)
         sparse_type = type(S)

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -58,7 +58,7 @@ Code details
 """
 import warnings
 import numpy as np
-from scipy.sparse import issparse, coo_array, dia_array, bsr_array, csr_array
+from scipy.sparse import identity, issparse, coo_array, dia_array, bsr_array, csr_array
 
 
 def expand(S, modes, N):
@@ -78,8 +78,6 @@ def expand(S, modes, N):
         array: the resulting :math:`2N\times 2N` Symplectic matrix
     """
     M = S.shape[0] // 2
-    S2 = np.identity(2 * N)
-
     if issparse(S):
         # cast to sparse matrix that supports slicing and indexing
         if isinstance(S, (coo_array, dia_array, bsr_array)):
@@ -87,8 +85,9 @@ def expand(S, modes, N):
                 "Unsupported sparse matrix type, returning a Compressed Sparse Row (CSR) matrix."
             )
             S = csr_array(S)
-        sparse_type = type(S)
-        S2 = sparse_type(S2, dtype=S.dtype)
+            S2 = identity(2 * N, dtype=S.dtype, format="csr")
+    else:
+        S2 = np.identity(2 * N, dtype=S.dtype)
 
     w = np.array([modes]) if isinstance(modes, int) else np.array(modes)
 

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -87,6 +87,7 @@ def expand(S, modes, N):
 
     return S2
 
+
 def extend(S, modes, N):
     r"""Extends a single mode symplectic to act on multiple modes.
 
@@ -101,11 +102,11 @@ def extend(S, modes, N):
     M = len(S) // 2
     w = np.array([modes]) if isinstance(modes, int) else np.array(modes)
 
-    if not(M == 1 and w.shape[0] > M):
+    if not (M == 1 and w.shape[0] > M):
         raise ValueError(f"`extend` expects a symplectic of size 1, got size {M}.")
 
     # Extend single-mode gate to repeatedly act on several modes
-    return block_diag(*[S.copy() if mode in w else np.zeros((2,2)) for mode in range(N)])
+    return block_diag(*[S.copy() if mode in w else np.zeros((2, 2)) for mode in range(N)])
 
 
 def expand_vector(alpha, mode, N, hbar=2.0):

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -63,6 +63,10 @@ from sympy import true
 
 def expand(S, modes, N):
     r"""Expands a Symplectic matrix S to act on the entire subsystem.
+    If the symplectic is single mode :math:`2\times 2` and the number
+    of modes is more than one, then the single-mode gate is made
+    to repeatedly act on the relevant ``modes``.
+
 
     Args:
         S (array): a :math:`2M\times 2M` Symplectic matrix

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -702,14 +702,14 @@ class TestSymplecticExpansion:
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("N", range(3,6))
-    def test_expand_one_mode_gate_to_many_modes(self, N, tol):
+    def test_extend_single_mode_symplectic(self, N, tol):
         """Test that passing a single mode symplectic along with many modes
         makes the gate act on those modes."""
 
         modes = np.random.choice(N, N-1, replace=False)
 
         S = random_symplectic(1)
-        res = symplectic.expand(S, modes=modes, N=N)
+        res = symplectic.extend(S, modes=modes, N=N)
 
         for m in range(N):
             if m in modes:

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -701,21 +701,23 @@ class TestSymplecticExpansion:
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("N", range(3,6))
+    @pytest.mark.parametrize("N", range(3, 6))
     def test_extend_single_mode_symplectic(self, N, tol):
         """Test that passing a single mode symplectic along with many modes
         makes the gate act on those modes."""
 
-        modes = np.random.choice(N, N-1, replace=False)
+        modes = np.random.choice(N, N - 1, replace=False)
 
         S = random_symplectic(1)
         res = symplectic.extend(S, modes=modes, N=N)
 
         for m in range(N):
             if m in modes:
-                assert np.allclose(res[2*m:2*m+2, 2*m:2*m+2], S, atol=tol, rtol=0)
+                assert np.allclose(res[2 * m : 2 * m + 2, 2 * m : 2 * m + 2], S, atol=tol, rtol=0)
             else:
-                assert np.allclose(res[2*m:2*m+2, 2*m:2*m+2], np.zeros((2,2)), atol=tol, rtol=0)
+                assert np.allclose(
+                    res[2 * m : 2 * m + 2, 2 * m : 2 * m + 2], np.zeros((2, 2)), atol=tol, rtol=0
+                )
 
 
 class TestIntegration:

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -714,16 +714,16 @@ class TestSymplecticExpansion:
         for m in range(N):
             if m in modes:
                 # check the symplectic acts on the mode m
-                assert np.allclose(res[m, m], S[0, 0], atol=tol, rtol=0)   # X
-                assert np.allclose(res[m + N, m + N], S[1, 1], atol=tol, rtol=0)   # P
-                assert np.allclose(res[m, m + N], S[0, 1], atol=tol, rtol=0)   # XP
-                assert np.allclose(res[m + N, m], S[1, 0], atol=tol, rtol=0)   # PX
+                assert np.allclose(res[m, m], S[0, 0], atol=tol, rtol=0)  # X
+                assert np.allclose(res[m + N, m + N], S[1, 1], atol=tol, rtol=0)  # P
+                assert np.allclose(res[m, m + N], S[0, 1], atol=tol, rtol=0)  # XP
+                assert np.allclose(res[m + N, m], S[1, 0], atol=tol, rtol=0)  # PX
             else:
                 # check the identity acts on the mode m
-                assert np.allclose(res[m, m], 1, atol=tol, rtol=0)   # X
-                assert np.allclose(res[m + N, m + N], 1, atol=tol, rtol=0)   # P
-                assert np.allclose(res[m, m + N], 0, atol=tol, rtol=0)   # XP
-                assert np.allclose(res[m + N, m], 0, atol=tol, rtol=0)   # PX
+                assert np.allclose(res[m, m], 1, atol=tol, rtol=0)  # X
+                assert np.allclose(res[m + N, m + N], 1, atol=tol, rtol=0)  # P
+                assert np.allclose(res[m, m + N], 0, atol=tol, rtol=0)  # XP
+                assert np.allclose(res[m + N, m], 0, atol=tol, rtol=0)  # PX
 
 
 class TestIntegration:

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -26,7 +26,6 @@ from scipy.sparse import (
     coo_array,
     dia_array,
     issparse,
-    isspmatrix_bsr,
 )
 
 from thewalrus import symplectic

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -20,6 +20,7 @@ from scipy.linalg import block_diag
 
 from thewalrus import symplectic
 from thewalrus.quantum import is_valid_cov
+from thewalrus.random import random_symplectic
 
 
 # pylint: disable=too-few-public-methods
@@ -699,6 +700,22 @@ class TestSymplecticExpansion:
         expected[m2 + N, m1 + N] = S[3, 2]
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("N", range(3,6))
+    def test_expand_one_mode_gate_to_many_modes(self, N, tol):
+        """Test that passing a single mode symplectic along with many modes
+        makes the gate act on those modes."""
+
+        modes = np.random.choice(N, N-1, replace=False)
+
+        S = random_symplectic(1)
+        res = symplectic.expand(S, modes=modes, N=N)
+
+        for m in range(N):
+            if m in modes:
+                assert np.allclose(res[2*m:2*m+2, 2*m:2*m+2], S, atol=tol, rtol=0)
+            else:
+                assert np.allclose(res[2*m:2*m+2, 2*m:2*m+2], np.zeros((2,2)), atol=tol, rtol=0)
 
 
 class TestIntegration:


### PR DESCRIPTION
**Context:**
No method is provided to extend a single-mode symplectic to act on several modes.

**Description of the Change:**
- Implements the new `extend` function to do just so.
- It works on sparse matrices as well. COO, DIA and BSR sparse matrices will be casted to CSR.

**Benefits:**
- New useful functionality  📏
- Works on sparse matrices.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None