### PR TITLE
Sampling speedup

### DIFF
--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -269,7 +269,9 @@ def hafnian_sample_state(
         np.array[int]: photon number samples from the Gaussian state
     """
     if parallel:
-        params = [[cov, 1, mean, hbar, cutoff, max_photons, approx, approx_samples]] * samples
+        params = [
+            [cov, 1, mean, hbar, cutoff, max_photons, approx, approx_samples]
+        ] * samples
         compute_list = []
         for p in params:
             compute_list.append(dask.delayed(_hafnian_sample)(p))
@@ -283,7 +285,14 @@ def hafnian_sample_state(
 
 
 def hafnian_sample_graph(
-    A, n_mean, samples=1, cutoff=5, max_photons=30, approx=False, approx_samples=1e5, parallel=False
+    A,
+    n_mean,
+    samples=1,
+    cutoff=5,
+    max_photons=30,
+    approx=False,
+    approx_samples=1e5,
+    parallel=False,
 ):
     r"""Returns samples from the Gaussian state specified by the adjacency matrix :math:`A`
     and with total mean photon number :math:`n_{mean}`
@@ -427,7 +436,9 @@ def _torontonian_sample(args):
     j = 0
 
     while j < samples:
-        result = generate_torontonian_sample(cov, mu, hbar=hbar, max_photons=max_photons)
+        result = generate_torontonian_sample(
+            cov, mu, hbar=hbar, max_photons=max_photons
+        )
         if result != -1:
             samples_array.append(result)
             j = j + 1
@@ -435,7 +446,9 @@ def _torontonian_sample(args):
     return np.vstack(samples_array)
 
 
-def torontonian_sample_state(cov, samples, mu=None, hbar=2, max_photons=30, parallel=False):
+def torontonian_sample_state(
+    cov, samples, mu=None, hbar=2, max_photons=30, parallel=False
+):
     r"""Returns samples from the Torontonian of a Gaussian state
 
     Args:
@@ -550,7 +563,10 @@ def torontonian_sample_classical_state(cov, samples, mean=None, hbar=2, atol=1e-
         np.array[int]: threshold samples from the Gaussian state with covariance cov and vector means mean.
     """
     return np.where(
-        hafnian_sample_classical_state(cov, samples, mean=mean, hbar=hbar, atol=atol) > 0, 1, 0
+        hafnian_sample_classical_state(cov, samples, mean=mean, hbar=hbar, atol=atol)
+        > 0,
+        1,
+        0,
     )
 
 
@@ -574,7 +590,9 @@ def photon_number_sampler(probabilities, num_samples, out_of_bounds=False):
         probabilities = probabilities.flatten() / sum_p
         vals = np.arange(cutoff**num_modes, dtype=int)
         return [
-            np.unravel_index(np.random.choice(vals, p=probabilities), [cutoff] * num_modes)
+            np.unravel_index(
+                np.random.choice(vals, p=probabilities), [cutoff] * num_modes
+            )
             for _ in range(num_samples)
         ]
 

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -66,6 +66,8 @@ from .quantum import (
     is_classical_cov,
     reduced_gaussian,
     density_matrix_element,
+    is_pure_cov,
+    pure_state_amplitude,
 )
 
 __all__ = [
@@ -124,6 +126,7 @@ def generate_hafnian_sample(
         local_mu = np.zeros(2 * N)
     else:
         local_mu = mean
+    pure_cov = is_pure_cov(cov, hbar=hbar)
 
     for k in range(N):
         total_photons = int(np.sum(result))
@@ -153,9 +156,20 @@ def generate_hafnian_sample(
                     / normalisation
                 )
             else:
-                prob_i = density_matrix_element(
-                    mu_red, V_red, indices, indices, include_prefactor=True, hbar=hbar
-                ).real
+                if (k == N - 1) and (pure_cov == True):
+                    amp_i = pure_state_amplitude(
+                        mu_red, cov, indices, hbar=hbar, check_purity=False
+                    )
+                    prob_i = np.abs(amp_i) ** 2
+                else:
+                    prob_i = density_matrix_element(
+                        mu_red,
+                        V_red,
+                        indices,
+                        indices,
+                        include_prefactor=True,
+                        hbar=hbar,
+                    ).real
 
             prob_cumulative += prob_i / prev_prob
             if prob_cumulative >= sample:

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -88,7 +88,13 @@ __all__ = [
 
 # pylint: disable=too-many-branches
 def generate_hafnian_sample(
-    cov, mean=None, hbar=2, cutoff=6, max_photons=30, approx=False, approx_samples=1e5
+    cov,
+    mean=None,
+    hbar=2,
+    cutoff=None,
+    max_photons=30,
+    approx=False,
+    approx_samples=1e5,
 ):  # pylint: disable=too-many-branches
     r"""Returns a single sample from the Hafnian of a Gaussian state.
 
@@ -112,6 +118,8 @@ def generate_hafnian_sample(
     N = len(cov) // 2
     result = []
     prev_prob = 1.0
+    if cutoff is None:
+        cutoff = max_photons + 1
     if mean is None:
         local_mu = np.zeros(2 * N)
     else:


### PR DESCRIPTION
### Before submitting

**Context:**
Some speedups for sampling from a GBS distribution.

**Description of the Change:**
The current generate_hafnian_sample function calculates hafnians of matrices larger than (twice) the sampled number of photons in each mode. This can be avoided by first sampling a random number and calculating the cumulative probability for increasing photon numbers and stopping once the cumulative probability has reached the sampled number. The loops have also been reduced to return -1 sooner if the sampling fails and the final mode can use pure_state_amplitude if the covariance matrix is pure. Finally the absolute function in the approximate case has been removed so that in the case of a non-positive matrix it throws an error rather than giving a sample from the wrong distribution.

**Benefits:**
Faster sampling than the current method.

There is another pull request that replaces this function with the quadratically faster algorithm. For higher numbers of photons in the sample that function will be faster. However, for lower numbers of photons this suggested method may be faster (depending on the cutoff supplied in the quadratic speedup version) as it does not need to calculate larger matrices than the number of photons sampled regardless of the cutoff chosen. This method is also exact up to a global cutoff whereas the quadratic speedup algorithm has some error due to the cutoff in each mode. In order to sample exactly, the cutoff in each mode needs to be the same as the global cutoff and so the cutoff kwarg is set to None which becomes the total number of photons +1.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None