### PR TITLE
[hotfix] create sparse or dense identity matrix accordingly

### DIFF
--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -85,16 +85,18 @@ def expand(S, modes, N):
         array: the resulting :math:`2N\times 2N` Symplectic matrix
     """
     M = S.shape[0] // 2
-    S2 = np.identity(2 * N, dtype=S.dtype)
+    S2 = (
+        np.identity(2 * N, dtype=S.dtype)
+        if not issparse(S)
+        else sparse_identity(2 * N, dtype=S.dtype, format="csr")
+    )
 
-    if issparse(S):
+    if issparse(S) and isinstance(S, (coo_array, dia_array, bsr_array)):
         # cast to sparse matrix that supports slicing and indexing
-        S2 = sparse_identity(2 * N, dtype=S.dtype, format="csr")
-        if isinstance(S, (coo_array, dia_array, bsr_array)):
-            warnings.warn(
-                "Unsupported sparse matrix type, returning a Compressed Sparse Row (CSR) matrix."
-            )
-            S = csr_array(S)
+        warnings.warn(
+            "Unsupported sparse matrix type, returning a Compressed Sparse Row (CSR) matrix."
+        )
+        S = csr_array(S)
 
     w = np.array([modes]) if isinstance(modes, int) else np.array(modes)
 


### PR DESCRIPTION
**Context:**
PR #347 introduced support for scipy's sparse matrices on the `expand` function. When dealing with such, first a dense identity matrix is created before checking if sparse matrices are used, the creation of this dense matrix leads to memory errors for large matrices.

**Description of the Change:**
Create the identity matrix accordingly (sparse or dense).

**Benefits:**
Avoids memory issues.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None