### PR TITLE
Instabilities of displacement operator

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 * Added function to extend single mode symplectic to act on multiple modes. [(#347)](https://github.com/XanaduAI/thewalrus/pull/347)
 
+* The displacement function now calculates the displacement operator's matrix elements with respect to the Fock basis using the Laguerre
+  polynomials. This provides enhanced numerical stability for larger cutoff values. [(#351)](https://github.com/XanaduAI/thewalrus/pull/351)
+
 ### Bug fixes
 
 * Remove redundant call of `Qmat`, `Amat` from `generate_hafnian_sample`. [(#343)](https://github.com/XanaduAI/thewalrus/pull/343)
@@ -22,7 +25,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Mikhail Andrenkov, Antonín Hoskovec
+Mikhail Andrenkov, Sebastián Duque, Jacon Hastrup, Antonín Hoskovec, Filippo Miatto
 
 ---
 

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -58,14 +58,14 @@ def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
     """
     D = np.zeros((cutoff, cutoff), dtype=dtype)
     alpha = r * np.exp(1j * phi)
+
+    factorial = np.arange(0, cutoff)
+    factorial[0] = 1
+    factorial_sqrt = np.cumprod(np.sqrt(factorial))
+
     for n_minus_m in range(cutoff):
         m_max = cutoff - n_minus_m
-
         L = _laguerre(r**2.0, m_max, n_minus_m)
-
-        factorial = np.arange(0, cutoff)
-        factorial[0] = 1
-        factorial_sqrt = np.cumprod(np.sqrt(factorial))
 
         alpha_nmm = alpha**n_minus_m
         e_alpha = np.exp(-np.abs(alpha) ** 2.0 / 2.0)

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -43,6 +43,22 @@ import numpy as np
 
 from numba import jit
 
+@jit(nopython=True, cache=True)
+def laguerre(x, N, alpha, dtype=np.complex128):
+    """Returns the N first generalized Laguerre polynomials evaluated at x.
+
+    Args:
+        x (float): point at which to evaluate the polynomials
+        N (int): maximum Laguerre polynomial to calculate
+        alpha (float): continuous parameter for the generalized Laguerre polynomials
+    """
+    L = np.zeros(N, dtype=dtype)
+    L[0] = 1.0
+    if N > 1:
+        L[1] = 1 + alpha - x
+        for m in range(1, N - 1):
+            L[m + 1] = ((2 * m + 1 + alpha - x) * L[m] - (m + alpha) * L[m - 1]) / (m + 1)
+    return L
 
 @jit(nopython=True)
 def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
@@ -58,16 +74,22 @@ def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
         array[complex]: matrix representing the displacement operation.
     """
     D = np.zeros((cutoff, cutoff), dtype=dtype)
-    sqrt = np.sqrt(np.arange(cutoff, dtype=dtype))
-    mu = np.array([r * np.exp(1j * phi), -r * np.exp(-1j * phi)])
+    ee = np.exp(-r ** 2.0 / 2.0)
 
-    D[0, 0] = np.exp(-0.5 * r**2)
-    for m in range(1, cutoff):
-        D[m, 0] = mu[0] / sqrt[m] * D[m - 1, 0]
+    factorial = np.zeros((cutoff,), dtype=dtype)
+    factorial[0] = 1
+    for n in range(1, cutoff):
+        factorial[n] = n*factorial[n-1]
 
-    for m in range(cutoff):
-        for n in range(1, cutoff):
-            D[m, n] = mu[1] / sqrt[n] * D[m, n - 1] + sqrt[m] / sqrt[n] * D[m - 1, n - 1]
+    for n_minus_m in range(cutoff):
+        m_max = cutoff - n_minus_m
+        L = laguerre(r, m_max, n_minus_m)
+        alpha_n_minus_m = r ** n_minus_m * np.exp(1j*phi*n_minus_m)
+
+        for m in range(m_max):
+            n = n_minus_m + m
+            D[n, m] = alpha_n_minus_m * ee * np.sqrt(factorial[m]/factorial[n]) * L[m]
+            D[m, n] = (-1.0) ** n_minus_m * D[n, m]
 
     return D
 

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -42,7 +42,7 @@ Code details
 import numpy as np
 from numba import jit
 
-SQRT = np.sqrt(np.arange(1E6))
+SQRT = np.sqrt(np.arange(1e6))
 
 
 @jit(nopython=True)
@@ -68,7 +68,13 @@ def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
         logL = np.log(_laguerre(r**2.0, m_max, n_minus_m))
         for m in range(m_max):
             n = n_minus_m + m
-            D[n, m] = np.exp(0.5*(log_k_fac[m] - log_k_fac[n]) + n_minus_m * np.log(r) - (r**2.0) / 2.0 + 1j * phi * n_minus_m + logL[m])
+            D[n, m] = np.exp(
+                0.5 * (log_k_fac[m] - log_k_fac[n])
+                + n_minus_m * np.log(r)
+                - (r**2.0) / 2.0
+                + 1j * phi * n_minus_m
+                + logL[m]
+            )
             D[m, n] = (-1.0) ** (n_minus_m) * np.conj(D[n, m])
     return D
 
@@ -85,8 +91,7 @@ def _laguerre(x, N, alpha, dtype=np.complex128):
     L = np.zeros(N, dtype=dtype)
     L[0] = 1.0
     if N > 1:
-        L[1] = 1 + alpha - x
-        for m in range(1, N - 1):
+        for m in range(0, N - 1):
             L[m + 1] = ((2 * m + 1 + alpha - x) * L[m] - (m + alpha) * L[m - 1]) / (m + 1)
     return L
 
@@ -116,9 +121,12 @@ def grad_displacement(T, r, phi):  # pragma: no cover
     for m in range(cutoff):
         for n in range(cutoff):
             grad_r[m, n] = -r * T[m, n] + sqrt[m] * ei * T[m - 1, n] - sqrt[n] * eic * T[m, n - 1]
-            grad_phi[m, n] = (sqrt[m] * 1j * alpha * T[m - 1, n] + sqrt[n] * 1j * alphac * T[m, n - 1])
+            grad_phi[m, n] = (
+                sqrt[m] * 1j * alpha * T[m - 1, n] + sqrt[n] * 1j * alphac * T[m, n - 1]
+            )
 
     return grad_r, grad_phi
+
 
 @jit(nopython=True)
 def squeezing(r, theta, cutoff, dtype=np.complex128):  # pragma: no cover

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -90,7 +90,8 @@ def _laguerre_renormalized(x, N, alpha, dtype=np.complex128):
     if N > 1:
         L[1] = (1 + alpha - x) * L[0] / np.sqrt(alpha+1)
         for m in range(1, N - 1):
-            L[m + 1] = ((2 * m + 1 + alpha - x) * L[m] * np.sqrt((m + 1)/(alpha+m+1)) - (m + alpha) * L[m - 1] * np.sqrt(m*(m + 1)/((alpha+m+1)*(alpha+m)))) / (m + 1)
+            L[m + 1] = ((2 * m + 1 + alpha - x) * L[m] * np.sqrt((m + 1)/(alpha+m+1))
+                    - (m + alpha) * L[m - 1] * np.sqrt(m*(m + 1)/((alpha+m+1)*(alpha+m)))) / (m + 1)
     return L
 
 

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -80,7 +80,7 @@ def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
 
 
 @jit(nopython=True, cache=True)
-def _laguerre(x, N, alpha, dtype=np.complex128):
+def _laguerre(x, N, alpha, dtype=np.complex128):  # pragma: no cover
     r"""Returns the N first generalized Laguerre polynomials evaluated at x.
 
     Args:

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -48,6 +48,7 @@ SQRT = np.sqrt(np.arange(1E6))
 @jit(nopython=True)
 def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
     r"""Calculates the matrix elements of the displacement gate using a recurrence relation.
+    Uses the log of the matrix elements to avoid numerical issues and then takes the exponential.
 
     Args:
         r (float): displacement magnitude
@@ -64,12 +65,11 @@ def displacement(r, phi, cutoff, dtype=np.complex128):  # pragma: no cover
     log_k_fac = np.cumsum(np.log(rng))
     for n_minus_m in range(cutoff):
         m_max = cutoff - n_minus_m
-        L = np.log(_laguerre(r**2.0, m_max, n_minus_m))
+        logL = np.log(_laguerre(r**2.0, m_max, n_minus_m))
         for m in range(m_max):
             n = n_minus_m + m
-            D[n, m] = np.exp(0.5*(log_k_fac[m] - log_k_fac[n]) + n_minus_m * np.log(r) - (r**2.0) / 2.0 + 1j * phi * n_minus_m + L[m])
+            D[n, m] = np.exp(0.5*(log_k_fac[m] - log_k_fac[n]) + n_minus_m * np.log(r) - (r**2.0) / 2.0 + 1j * phi * n_minus_m + logL[m])
             D[m, n] = (-1.0) ** (n_minus_m % 2) * np.conj(D[n, m])
-
     return D
 
 

--- a/thewalrus/tests/test_fock_gradients.py
+++ b/thewalrus/tests/test_fock_gradients.py
@@ -187,7 +187,7 @@ def test_laguerre_values(tol, x, alpha):
     res = _laguerre(x, N, alpha)
     expected = np.array([genlaguerre(n=ni, alpha=alpha)(x) for ni in range(N)])
 
-    assert np.allclose(res, expected)
+    assert np.allclose(res, expected, atol=tol)
 
 
 def test_squeezing_values(tol):

--- a/thewalrus/tests/test_fock_gradients.py
+++ b/thewalrus/tests/test_fock_gradients.py
@@ -24,8 +24,10 @@ from thewalrus.fock_gradients import (
     grad_beamsplitter,
     mzgate,
     grad_mzgate,
+    _laguerre,
 )
 import numpy as np
+from scipy.special import genlaguerre
 import pytest
 
 
@@ -175,6 +177,17 @@ def test_displacement_values(tol):
     )
     T = displacement(np.abs(alpha), np.angle(alpha), cutoff)
     assert np.allclose(T, expected, atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("alpha", np.linspace(-0.9, 10, 15))
+@pytest.mark.parametrize("x", np.linspace(-5, 10, 15))
+def test_laguerre_values(tol, x, alpha):
+    """Test recursive calculation of laguerre polynomials give the correct result"""
+    N = 10
+    res = _laguerre(x, N, alpha)
+    expected = np.array([genlaguerre(n=ni, alpha=alpha)(x) for ni in range(N)])
+
+    assert np.allclose(res, expected)
 
 
 def test_squeezing_values(tol):


### PR DESCRIPTION
**Context:**
Currently The Walrus uses the recursion relations for the displacement operator found in [Fast optimization of parametrized quantum optical circuits](https://quantum-journal.org/papers/q-2020-11-30-366/#). This approach leads to numerical instabilities for large cutoff and displacement values — as pointed out by @JacobHast.

**Description of the Change:**
This PR makes the use of the displacement operator's matrix elements with respect to the Fock basis as shown in [Ordered Expansions in Boson Amplitude Operators](https://journals.aps.org/pr/abstract/10.1103/PhysRev.177.1857).

Comparison plots:

`D=30, cutoff=2500`

![displacement_fixed](https://user-images.githubusercontent.com/675763/186187333-22387d6c-2f03-48a7-a09f-eb750b848da8.png)

![displacement_base](https://user-images.githubusercontent.com/675763/186187311-52e3ad84-ac83-46c1-8d22-199d01083ccb.png)

**Benefits:**
Numerically stable displacement operation.

**Possible Drawbacks:**
From a quick benchmark, the performance of the former approach is slightly faster (`r=10`, `phi=0`, `cutoff=200`)

- Former approach: **267 µs ± 654 ns** per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

- This PR: **288 µs ± 341 ns** per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

**Related GitHub Issues:**
None