### PR TITLE
Revert "Instabilities of displacement operator (#351)"

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 * Added function to extend single mode symplectic to act on multiple modes. [(#347)](https://github.com/XanaduAI/thewalrus/pull/347)
 
-* The displacement function now calculates the displacement operator's matrix elements with respect to the Fock basis using the Laguerre polynomials. This provides enhanced numerical stability for larger cutoff values. [(#351)](https://github.com/XanaduAI/thewalrus/pull/351)
-
 ### Bug fixes
 
 * Remove redundant call of `Qmat`, `Amat` from `generate_hafnian_sample`. [(#343)](https://github.com/XanaduAI/thewalrus/pull/343)

--- a/thewalrus/tests/test_fock_gradients.py
+++ b/thewalrus/tests/test_fock_gradients.py
@@ -24,10 +24,8 @@ from thewalrus.fock_gradients import (
     grad_beamsplitter,
     mzgate,
     grad_mzgate,
-    _laguerre,
 )
 import numpy as np
-from scipy.special import genlaguerre
 import pytest
 
 
@@ -177,17 +175,6 @@ def test_displacement_values(tol):
     )
     T = displacement(np.abs(alpha), np.angle(alpha), cutoff)
     assert np.allclose(T, expected, atol=tol, rtol=0)
-
-
-@pytest.mark.parametrize("alpha", np.linspace(-0.9, 10, 15))
-@pytest.mark.parametrize("x", np.linspace(-5, 10, 15))
-def test_laguerre_values(tol, x, alpha):
-    """Test recursive calculation of laguerre polynomials give the correct result"""
-    N = 10
-    res = _laguerre(x, N, alpha)
-    expected = np.array([genlaguerre(n=ni, alpha=alpha)(x) for ni in range(N)])
-
-    assert np.allclose(res, expected, atol=tol)
 
 
 def test_squeezing_values(tol):


### PR DESCRIPTION
This reverts commit 9d8fe40ace7495b707894ef760c2592197a9e27b.

**Context:**
PR #351 implemented the displacement operation using Laguerre Polynomials instead of the previously used recursion relations.

**Description of the Change:**
This PR reverts The Walrus to use the recursion relations for the displacement operator instead of the Laguerre Polynomials, the reason being that the new change breaks operations in Strawberry Fields as evidenced in [SF PR #725](https://github.com/XanaduAI/strawberryfields/pull/725).

**Benefits:**
Given the strong coupling between Strawberry Fields and The Walrus, this PR will ensure a consistent state of development between the libraries and avoids breaking changes that will eventually propagate to the users.

**Possible Drawbacks:**
The displacement gate on The Walrus and Strawberry Fields will be unstable for large values of the arguments/cutoff.

**Related GitHub Issues:**
[SF PR #725](https://github.com/XanaduAI/strawberryfields/pull/725)