### PR TITLE
format with black

### DIFF
--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -441,7 +441,6 @@ def _calc_hafnian(A, edge_reps, glynn=True):  # pragma: no cover
     H = np.complex128(0)  # start running total for the hafnian
 
     for j in numba.prange(steps):
-
         kept_edges = find_kept_edges(j, edge_reps)
         edge_sum = kept_edges.sum()
 
@@ -545,7 +544,6 @@ def _calc_loop_hafnian(A, D, edge_reps, oddloop=None, oddV=None, glynn=True):  #
     H = np.complex128(0)  # Start running total for the hafnian
 
     for j in numba.prange(steps):
-
         kept_edges = find_kept_edges(j, edge_reps)
         edge_sum = kept_edges.sum()
 

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -967,11 +967,9 @@ def hafnian_banded(A, loop=False, rtol=1e-05, atol=1e-08):
         for D in ps:
             if lower_end + D not in loop_haf:
                 loop_haf[lower_end + D] = sum(
-                    [
-                        A[i - 1, t - 1]
-                        * loop_haf[tuple(item for item in lower_end + D if item not in set((i, t)))]
-                        for i in D
-                    ]
+                    A[i - 1, t - 1]
+                    * loop_haf[tuple(item for item in lower_end + D if item not in set((i, t)))]
+                    for i in D
                 )
 
     return loop_haf[tuple(range(1, n + 1))]

--- a/thewalrus/loop_hafnian_batch.py
+++ b/thewalrus/loop_hafnian_batch.py
@@ -46,6 +46,7 @@ from thewalrus._hafnian import (
     get_submatrix_batch_odd0,
 )
 
+
 # pylint: disable = too-many-arguments, not-an-iterable
 @numba.jit(nopython=True, parallel=True, cache=True)
 def _calc_loop_hafnian_batch_even(
@@ -83,7 +84,6 @@ def _calc_loop_hafnian_batch_even(
     H_batch = np.zeros(2 * batch_max + odd_cutoff + 1, dtype=np.complex128)
     # prange to range
     for j in numba.prange(steps):
-
         Hnew = np.zeros(2 * batch_max + odd_cutoff + 1, dtype=np.complex128)
 
         kept_edges = find_kept_edges(j, edge_reps)
@@ -163,7 +163,6 @@ def _calc_loop_hafnian_batch_odd(
 
     H_batch = np.zeros(2 * batch_max + even_cutoff + 2, dtype=np.complex128)
     for j in numba.prange(steps):
-
         Hnew = np.zeros(2 * batch_max + even_cutoff + 2, dtype=np.complex128)
 
         kept_edges = find_kept_edges(j, edge_reps)

--- a/thewalrus/loop_hafnian_batch_gamma.py
+++ b/thewalrus/loop_hafnian_batch_gamma.py
@@ -47,6 +47,7 @@ from thewalrus._hafnian import (
 )
 from thewalrus.loop_hafnian_batch import add_batch_edges_odd, add_batch_edges_even
 
+
 # pylint: disable = too-many-arguments, not-an-iterable
 @numba.jit(nopython=True, cache=True, parallel=True)
 def _calc_loop_hafnian_batch_gamma_even(
@@ -85,7 +86,6 @@ def _calc_loop_hafnian_batch_gamma_even(
     H_batch = np.zeros((n_D, 2 * batch_max + odd_cutoff + 1), dtype=np.complex128)
 
     for j in prange(steps):
-
         Hnew = np.zeros((n_D, 2 * batch_max + odd_cutoff + 1), dtype=np.complex128)
 
         kept_edges = find_kept_edges(j, edge_reps)
@@ -171,7 +171,6 @@ def _calc_loop_hafnian_batch_gamma_odd(
     H_batch = np.zeros((n_D, 2 * batch_max + even_cutoff + 2), dtype=np.complex128)
     # for j in range(rank, steps, size):
     for j in prange(steps):
-
         Hnew = np.zeros((n_D, 2 * batch_max + even_cutoff + 2), dtype=np.complex128)
 
         kept_edges = find_kept_edges(j, edge_reps)

--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -88,6 +88,7 @@ __all__ = [
 # Hafnian sampling
 # ===============================================================================================
 
+
 # pylint: disable=too-many-branches
 def decompose_cov(cov):
     r"""Decompose the convariance matrix using the Williamson decomposition method.


### PR DESCRIPTION
**Context:**
The Walrus is formatted with black `v22.6.0` but a new version has been released (`v23.1.0`). CI uses the latest version of black to check for formatting and hence The Walrus is not passing the check.

**Description of the Change:**
Formats The Walrus using black `v23.1.0`.

**Benefits:**
Correct formatting

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
