### PR TITLE
Add Python 3.11 support and raise dependency versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.9gi
 
       - name: Install dependencies
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask[delayed]==2022.2.1
-numba==0.55.1
-numpy==1.21.5
-scipy==1.8.0
-sympy==1.10
+numba==0.56.4
+numpy==1.23.5
+scipy==1.10.1
+sympy==1.11.1

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]


### PR DESCRIPTION
**Context:**
This raises package versions and adds in support for python 3.11

**Description of the Change:**
Add Python 3.11 support and raise dependency versions

**Benefits:**
Start adding support for Xanadu packages for supporting Python 3.11

**Possible Drawbacks:**
Complexity of managing packages for Python 3.7 - 3.11

**Related GitHub Issues:**
