### PR TITLE
Tighten power-trace bound of odd loop Hafnian

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements
 
+* Tighten power-trace bound of odd loop Hafnian. [(#362)](https://github.com/XanaduAI/thewalrus/pull/362)
+
 ### Bug fixes
 
 ### Documentation

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -264,7 +264,7 @@ def f_loop_odd(AX, AX_S, XD_S, D_S, n, oddloop, oddVX_S):  # pragma: no cover
     count = 0
     comb = np.zeros((2, n + 1), dtype=np.complex128)
     comb[0, 0] = 1
-    powtrace = charpoly.powertrace(AX, n + 1)
+    powtrace = charpoly.powertrace(AX, n // 2 + 1)
     for i in range(1, n + 1):
         if i == 1:
             factor = oddloop


### PR DESCRIPTION
**Context:**: 
The loop Hafnian for odd sized matrices contains an excessive bound, making it a code readability issue and efficiency issue.

**Description of the Change:**
In the inner-loop, `powtrace[i // 2]` reaches a maximum at `n == i` according to the loop range, hence the power-trace need not compute any additional power traces.

**Benefits:**
Readability and efficiency.

**Possible Drawbacks:**

**Related GitHub Issues:**
