### PR TITLE
Refactor sphinx config and bump docs python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,17 +9,13 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
-# Build documentation with MkDocs
-#mkdocs:
-#  configuration: mkdocs.yml
-
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - htmlzip
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: 3.10
   install:
     - requirements: docs/requirements.txt
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,11 +13,14 @@ sphinx:
 formats:
   - htmlzip
 
-# Optionally set the version of Python and requirements required to build your docs
+# Set the version of Python and container image
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Set the requirements required to build your docs
 python:
-  version: 3.10
   install:
     - requirements: docs/requirements.txt
 
-build:
-  image: latest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,13 +1,13 @@
-docutils==0.16
+docutils
 sphinxcontrib-bibtex
-sphinx==3.5.3
+sphinx
 ipykernel
-nbsphinx==0.7
+nbsphinx
 numba>=0.49.1
 numpy>=1.9
 sympy>=1.5.1
 scipy>=1.8.0
-Jinja2==2.11.3
+Jinja2
 version_information
 sphinx-copybutton
 dask[delayed]


### PR DESCRIPTION
**Context:**
Sphinx doc builds were failing due to dependencies on deprecated or old package version when building the docs

**Description of the Change:**
This PR
- refactors the `.readthedocs.yml` configuration file to set the container version of the readthedocs builder
- bumps python version of the sphinx container to `v3.10`
- unpins requirements in `doc/requirements.txt` to use the latest version available of packages

**Benefits:**
Docs build and hopefully will continue to do so as dependent packages get upgraded

**Possible Drawbacks:**
Doc requirements is now unpinned

**Related GitHub Issues:**
None