### PR TITLE
Simpler and more elegant implementation of Williamson

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ### New features
 
+* Adds the Takagi decomposition [(#363)](https://github.com/XanaduAI/thewalrus/pull/338)
+
 ### Breaking changes
 
 ### Improvements
+
+* Simplifies the internal working of Bloch-Messiah decomposition [(#363)](https://github.com/XanaduAI/thewalrus/pull/338). 
+
+* Simplifies the internal working of Williamson decomposition [(#366)](https://github.com/XanaduAI/thewalrus/pull/338). 
 
 ### Bug fixes
 
@@ -12,7 +18,9 @@
 
 ### Contributors
 
-This release contains contributions from (in alphabetical order):
+This release contains contributions from (in alphabetical order): 
+
+Nicolas Quesada
 
 ---
 

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -85,11 +85,9 @@ def williamson(V, rtol=1e-05, atol=1e-08):
         if s1[2 * i, 2 * i + 1] <= 0:
             (perm1[2 * i], perm1[2 * i + 1]) = (perm1[2 * i + 1], perm1[2 * i])
 
-    perm2 = np.array([2 * i for i in range(n)] + [2 * i + 1 for i in range(n)])
+    perm2 = np.array([perm1[2 * i] for i in range(n)] + [perm1[2 * i + 1] for i in range(n)])
 
-    Kt = K[:, perm1]
-
-    Ktt = Kt[:, perm2]
+    Ktt = K[:, perm2]
     s1t = s1[:, perm1][perm1]
 
     dd = np.array([1 / s1t[2 * i, 2 * i + 1] for i in range(n)])
@@ -220,11 +218,10 @@ def takagi(A, svd_order=True):
         return vals, U * np.exp(1j * phi / 2)
 
     u, d, v = np.linalg.svd(A)
-    #U = u @ sqrtm((v @ np.conjugate(u)).T)
+    U = u @ sqrtm((v @ np.conjugate(u)).T)
     # The line above could be simplifed to the line below if the product v @ np.conjugate(u) is diagonal
     # Which it should be according to Caves http://info.phys.unm.edu/~caves/courses/qinfo-s17/lectures/polarsingularAutonne.pdf
     # U = u * np.sqrt(0j + np.diag(np.conjugate(u) @ v))
-    U = u @ sqrtm(np.diag(v @ np.conjugate(u)).T)
     # This however breaks test_degenerate
     if svd_order is False:
         return d[::-1], U[:, ::-1]

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -107,8 +107,8 @@ def symplectic_eigenvals(cov):
         (array): symplectic eigenvalues
     """
     M = int(len(cov) / 2)
-    D, _ = williamson(cov)
-    return np.diag(D)[:M]
+    Omega = sympmat(M)
+    return np.real_if_close(-1j * np.linalg.eigvals(Omega @ cov))[::2]
 
 
 def blochmessiah(S):

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -220,10 +220,11 @@ def takagi(A, svd_order=True):
         return vals, U * np.exp(1j * phi / 2)
 
     u, d, v = np.linalg.svd(A)
-    U = u @ sqrtm((v @ np.conjugate(u)).T)
+    #U = u @ sqrtm((v @ np.conjugate(u)).T)
     # The line above could be simplifed to the line below if the product v @ np.conjugate(u) is diagonal
     # Which it should be according to Caves http://info.phys.unm.edu/~caves/courses/qinfo-s17/lectures/polarsingularAutonne.pdf
-    # U = u * np.sqrt(0j + np.diag(v @ np.conjugate(u)))
+    # U = u * np.sqrt(0j + np.diag(np.conjugate(u) @ v))
+    U = u @ sqrtm(np.diag(v @ np.conjugate(u)).T)
     # This however breaks test_degenerate
     if svd_order is False:
         return d[::-1], U[:, ::-1]

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -70,9 +70,8 @@ def williamson(V, rtol=1e-05, atol=1e-08):
     omega = sympmat(n)
     vals = np.linalg.eigvalsh(V)
 
-    for val in vals:
-        if val <= 0:
-            raise ValueError("Input matrix is not positive definite")
+    if not np.all(vals > 0):
+        raise ValueError("Input matrix is not positive definite")
 
     Mm12 = sqrtm(np.linalg.inv(V)).real
     r1 = Mm12 @ omega @ Mm12

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -35,7 +35,7 @@ Code details
 """
 import numpy as np
 
-from scipy.linalg import sqrtm, schur
+from scipy.linalg import block_diag, sqrtm, schur
 from thewalrus.symplectic import sympmat
 from thewalrus.quantum.gaussian_checks import is_symplectic
 

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -35,7 +35,7 @@ Code details
 """
 import numpy as np
 
-from scipy.linalg import block_diag, sqrtm, schur
+from scipy.linalg import sqrtm, schur
 from thewalrus.symplectic import sympmat
 from thewalrus.quantum.gaussian_checks import is_symplectic
 


### PR DESCRIPTION
A simpler and more elegant implementation of the Williamson decompositions is implemented. In particular the new implementation

* Replaces a matrix multiplication by a permutation matrix  by a direct permutation of the columns of the matrix.
* The calculation of the matrix square root of a diagonal matrix by directly calculating the square roots of the diagonal elements
* The matrix multiplication of a diagonal matrix by a direct multiplication with the vector.