### PR TITLE
Add vscode devcontainer / github codespaces

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,0 +1,46 @@
+FROM python:3.10
+
+# Configure apt for setup
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOCSPORT 8080
+ENV PYTHONPATH "/workspaces/thewalrus"
+EXPOSE 8080
+
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends sudo \
+    zsh \
+    less \
+    curl \
+    wget \
+    fonts-powerline \
+    locales \
+    graphviz \
+    pandoc
+
+### GIT GLOBAL SETUP ###
+
+RUN git config --global core.excludesfile /.globalgitignore
+RUN touch /.globalgitignore
+RUN echo "nohup.out" >> /.globalgitignore
+
+### ZSH TERMINAL SETUP ###
+
+# generate locale for zsh terminal agnoster theme
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && /usr/sbin/locale-gen
+RUN locale-gen en_US.UTF-8
+# set term to be bash instead of sh
+ENV TERM xterm
+ENV SHELL /bin/zsh
+# install oh-my-zsh
+RUN sh -c "$(wget -O- https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+### PYTHON DEPENDENCIES INTALLATION ###
+
+# upgrade pip and install package manager
+RUN python -m pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir poetry==1.4.0
+RUN poetry config virtualenvs.create false
+
+### TEAR DOWN IMAGE SETUP ###
+# switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
+{
+	"name": "The Walrus",
+	"dockerFile": "dev.Dockerfile",
+	"postCreateCommand": "/bin/zsh ./.devcontainer/post-install.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.pylint",
+				"eamodio.gitlens",
+				"GitHub.vscode-pull-request-github",
+				"mutantdino.resourcemonitor",
+				"njpwerner.autodocstring"
+			],
+			"settings": {
+                "python.testing.pytestArgs": [
+                    "tests"
+                ],
+                "python.testing.unittestEnabled": false,
+                "python.testing.pytestEnabled": true,
+                "python.linting.pylintEnabled": true,
+                "python.linting.enabled": true,
+				"python.languageServer": "Pylance",
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.terminal.executeInFileDir": true,
+				"code-runner.fileDirectoryAsCwd": true,
+				"terminal.integrated.env.linux": {"PYTHONPATH": "/workspaces/thewalrus"},
+				"autoDocstring.docstringFormat": "google"
+            }
+		}
+	},
+	"remoteUser": "root"
+}

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -1,0 +1,6 @@
+#! /bin/zsh
+
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+pip install -r docs/requirements.txt
+pip install -e .


### PR DESCRIPTION
**Context:**
Have you dream of having many and completely environments (down to the operative system) on your local machine or even making changes to the walrus online?

**Description of the Change:**
This PR implements a fully furnished [vscode devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).

**Benefits:**
- Can create fully reproducible environments on different machines
- Enables (paid) github codespaces
- Allows you to run/debug the walrus on linux even when on a mac or windows machine

_How-to?_
- To try it out the devcontainer locally on vscode follow the instructions [here](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume),
- Use (**paid**, yes you _pay_ so be careful with usage) github codespaces
[
    ![Open in Remote - Containers](
        https://img.shields.io/static/v1?label=Remote%20-%20Containers&message=Open&color=blue&logo=visualstudiocode
    )
](
    https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/XanaduAI/thewalrus
)

**Possible Drawbacks:**
🤷

**Related GitHub Issues:**
None