### PR TITLE
Increment version number to `0.22.0-dev`

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Release 0.22.0-dev
+
+### New features
+
+### Breaking changes
+
+### Improvements
+
+### Bug fixes
+
+### Documentation
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+---
+
 # Release 0.21.0
 
 ### New features

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.21.0"
+__version__ = "0.22.0-dev"


### PR DESCRIPTION
The Walrus `v0.21.0` has been released. Starting a new development cycle.