### PR TITLE
Add Godsil-Gutman estimator

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Implements the pre-Iwasawa and Iwasawa decompositions for symplectic matrices [(#382)](https://github.com/XanaduAI/thewalrus/pull/382).
 
+* Implements the Godsil-Gutman estimator for the Hafnian of symmetric nonnegative matrices. 
+
 ### Breaking changes
 
 ### Improvements
@@ -21,7 +23,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Will McCutcheon, Nicolas Quesada
+Will McCutcheon, Nicolas Quesada, Alexey Uvarov
 
 ---
 

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -720,7 +720,6 @@ def hafnian(
     loop=False,
     rtol=1e-05,
     atol=1e-08,
-    approx=False,
     num_samples=1000,
     method="glynn",
 ):  # pylint: disable=too-many-arguments
@@ -734,14 +733,14 @@ def hafnian(
         method (string): Set this to ``"glynn"`` to use the
             glynn formula,
             or ``"inclexcl"`` to use the inclusion exclusion principle,
-            or ``"recursive"`` to use a recursive algorithm.
+            or ``"recursive"`` to use a recursive algorithm,
+            or ``"barvinok"`` to use an approximate Barvinok estimator (non-negative matrices only),
+            or ``"godsilgutman"`` to use an approximate Godsil-Gutman estimator (non-negative matrices only).
         rtol (float): the relative tolerance parameter used in ``np.allclose``
         atol (float): the absolute tolerance parameter used in ``np.allclose``
-        approx (bool): If ``True``, an approximation algorithm is used to estimate the hafnian. Note
-            that the approximation algorithm can only be applied to matrices ``A`` that only have
-            non-negative entries.
-        num_samples (int): If ``approx=True``, the approximation algorithm performs ``num_samples``
-            iterations for estimation of the hafnian of the non-negative matrix ``A``
+        num_samples (int): If ``method=barvinok`` or ``method=godsilgutman``, the approximation
+            algorithm performs ``num_samples`` iterations for estimation of the hafnian
+            of the non-negative matrix ``A``.
 
     Returns:
         int or float or complex: the hafnian of matrix ``A``
@@ -798,14 +797,14 @@ def hafnian(
 
         return A[0, 1] * A[2, 3] + A[0, 2] * A[1, 3] + A[0, 3] * A[1, 2]
 
-    if approx:
+    if method in {"godsilgutman", "barvinok"}:
         if np.any(np.iscomplex(A)):
             raise ValueError("Input matrix must be real")
 
         if np.any(A < 0):
             raise ValueError("Input matrix must not have negative entries")
 
-        return hafnian_approx(A, num_samples=num_samples)
+        return hafnian_approx(A, num_samples=num_samples, method=method)
 
     if loop:
         if method == "recursive":
@@ -1046,13 +1045,17 @@ def solve(b, s, w, g, n):  # pragma: no cover
 
 
 @numba.jit(nopython=True)
-def _one_det(B):  # pragma: no cover
+def _one_det(B, method="barvinok"):  # pragma: no cover
     """Calculates the determinant of an antisymmetric matrix with entries distributed
     according to a normal distribution, with scale equal to the entries of the symmetric matrix
     given as input.
 
     Args:
         B (array[float]): symmetric matrix
+        method (string): can take the following values denoting different estimators:
+            ``"barvinok"`` has a higher variance, but better bounds for single-shot estimates,
+            ``"godsilgutman"`` has a lower variance, but can fail to provide a nontrivial estimate with a small
+        number of shots.
 
     Returns:
         float: determinant of the samples antisymmetric matrix
@@ -1061,25 +1064,33 @@ def _one_det(B):  # pragma: no cover
     n, m = B.shape
     for i in range(n):
         for j in range(m):
-            mat[i, j] = B[i, j] * np.random.normal()
+            if method == "barvinok":
+                mat[i, j] = B[i, j] * np.random.normal()
+            elif method == "godsilgutman":
+                mat[i, j] = B[i, j] * (-1)**np.random.randint(2)
+            else:
+                raise ValueError()
             mat[j, i] = -mat[i, j]
     return np.linalg.det(mat)
 
 
 @numba.jit(nopython=True)
-def hafnian_approx(A, num_samples=1000):  # pragma: no cover
+def hafnian_approx(A, num_samples=1000, method="barvinok"):  # pragma: no cover
     """Returns the approximation to the hafnian of a matrix with non-negative entries.
 
-    The approximation follows the stochastic Barvinok's approximation allowing the
+    The approximation follows the stochastic approximation allowing the
     hafnian can be approximated as the sum of determinants of matrices.
     The accuracy of the approximation increases with increasing number of iterations.
 
     Args:
         B (array[float]): a symmetric matrix
-
+        method (string): can take the following values denoting different estimators:
+            ``"barvinok"`` has a higher variance, but better bounds for single-shot estimates,
+            ``"godsilgutman"`` has a lower variance, but can fail to provide a nontrivial estimate with a small
+        number of shots.
     Returns:
         float: approximate hafnian of the input
     """
 
     sqrtA = np.sqrt(A)
-    return np.array([_one_det(sqrtA) for _ in range(num_samples)]).mean()
+    return np.array([_one_det(sqrtA, method=method) for _ in range(num_samples)]).mean()

--- a/thewalrus/tests/test_hafnian_approx.py
+++ b/thewalrus/tests/test_hafnian_approx.py
@@ -29,7 +29,7 @@ def test_rank_one(n):
     x = np.random.rand(n)
     A = np.outer(x, x)
     exact = factorial2(n - 1) * np.prod(x)
-    approx = hafnian(A, approx=True, num_samples=10000)
+    approx = hafnian(A, method="barvinok", num_samples=10000)
     assert np.allclose(approx, exact, rtol=2e-1, atol=0)
 
 
@@ -37,7 +37,7 @@ def test_approx_complex_error():
     """Check exception raised if matrix is complex"""
     A = 1j * np.ones([6, 6])
     with pytest.raises(ValueError, match="Input matrix must be real"):
-        hafnian(A, approx=True)
+        hafnian(A, method="barvinok")
 
 
 def test_approx_negative_error():
@@ -45,13 +45,13 @@ def test_approx_negative_error():
     A = np.ones([6, 6])
     A[0, 0] = -1
     with pytest.raises(ValueError, match="Input matrix must not have negative entries"):
-        hafnian(A, approx=True)
+        hafnian(A, method="barvinok")
 
 
 @pytest.mark.parametrize("n", [6, 8])
 def test_ones_approx(n):
     """Check hafnian_approx(J_2n)=(2n)!/(n!2^n)"""
     A = np.float64(np.ones([2 * n, 2 * n]))
-    haf = hafnian(A, approx=True, num_samples=10000)
+    haf = hafnian(A, method="barvinok", num_samples=10000)
     expected = fac(2 * n) / (fac(n) * (2**n))
     assert np.abs(haf - expected) / expected < 0.2


### PR DESCRIPTION
**Context:**
Randomized estimators of the Hafnian of a nonnegative matrices can be implemented in two different manners. Previously ``hafnian_approx()`` only implemented one of them

**Description of the Change:**
Added an option to use the Godsil-Gutman estimator. Also changed the signature of ``hafnian()`` so that now all methods are controlled by the ``method`` parameter, and the ``approx`` parameter is removed as redundant.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
