### PR TITLE
reduced state fix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 * Add the calculation method of `takagi` when the matrix is diagonal. [(#394)](https://github.com/XanaduAI/thewalrus/pull/394)
 
-* Add the lines for avoiding the comparison of np.ndarray and list. 
+* Add the lines for avoiding the comparison of np.ndarray and list. [(#395)](https://github.com/XanaduAI/thewalrus/pull/395)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 * Add the calculation method of `takagi` when the matrix is diagonal. [(#394)](https://github.com/XanaduAI/thewalrus/pull/394)
 
+* Add the lines for avoiding the comparison of np.ndarray and list. 
+
 ### Documentation
 
 ### Contributors

--- a/thewalrus/symplectic.py
+++ b/thewalrus/symplectic.py
@@ -171,6 +171,9 @@ def reduced_state(mu, cov, modes):
     """
     N = len(mu) // 2
 
+    if type(modes) == np.ndarray:
+        modes = modes.tolist()
+
     if modes == list(range(N)):
         # reduced state is full state
         return mu, cov

--- a/thewalrus/tests/test_symplectic.py
+++ b/thewalrus/tests/test_symplectic.py
@@ -367,6 +367,15 @@ class TestReducedState:
         assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
         assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
 
+    def test_ndarray(self, hbar, tol):
+        """Test numpy.ndarray in the third argument of `reduced_state` is converted to list correctly"""
+        mu, cov = symplectic.vacuum_state(4, hbar=hbar)
+        res = symplectic.reduced_state(mu, cov, np.array([0, 1, 2, 3]))
+        expected = np.zeros([8]), np.identity(8) * hbar / 2
+
+        assert np.allclose(res[0], expected[0], atol=tol, rtol=0)
+        assert np.allclose(res[1], expected[1], atol=tol, rtol=0)
+
 
 class TestLossChannel:
     """Tests for the loss channel"""


### PR DESCRIPTION
**Context:**
There was a code that compare the value in numpy.ndarray and list in `reduced_state` (numpy.ndarray == list). This comparison was allowed in the previous version of numpy but prohibited in the latest one. Therefore, an error is raised. 

**Description of the Change:**
Codes to convert the type from numpy.ndarray to list was added.

**Benefits:**
The error is fixed.

**Possible Drawbacks:**
This change may break other parts because codes to restore the type after the comparison have not been implemented.

**Related GitHub Issues:**