### PR TITLE
Upgrade to `numpy 2` 

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12
+          python-version: 3.11
 
       - name: Install dependencies
         run:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.12
 
       - name: Install dependencies
         run:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,8 +20,8 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run:
-            python -m pip install --upgrade pip
+        shell: bash
+        run: |
             pip install black
 
       - uses: actions/checkout@v3

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.12'
 
       - name: Install dependencies
         run:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.10
 
@@ -24,7 +24,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install black
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run Black
         run: black -l 100 thewalrus/ --check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.10
 
       - name: Install dependencies
         run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,8 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
+        shell: bash
         run: |
-          python3 -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pytest pytest-cov pytest-randomly wheel codecov
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+          disable_search: true
           fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12
+          python-version: 3.11
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,8 @@ jobs:
         run: python3 -m pytest thewalrus --randomly-seed=137 --cov=thewalrus --cov-report term-missing --cov-report=html:coverage_html_report --cov-report=xml:coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout The Walrus
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.10
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.10
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-flaky==3.7.0
-pytest==7.1.0
-pytest-randomly==3.11.0
+flaky==3.8.1
+pytest==8.3.5
+pytest-randomly==3.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask[delayed]>=2022.2.1
-numba>=0.55.1
-numpy>=1.21.5
-scipy>=1.8.0
-sympy>=1.10
+dask[delayed]==2025.4.1
+numba==0.61.2
+numpy==2.2.5
+scipy==1.15.3
+sympy==1.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dask[delayed]==2025.4.1
 numba==0.61.2
 numpy==2.2.5
 scipy==1.15.3
-sympy==1.14.1
+sympy==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask[delayed]==2023.10.1
-numba==0.55.1
-numpy==1.21.5
-scipy==1.8.0
-sympy==1.10
+dask[delayed]>=2022.2.1
+numba>=0.55.1
+numpy>=1.21.5
+scipy>=1.8.0
+sympy>=1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask[delayed]==2022.2.1
+dask[delayed]==2023.10.1
 numba==0.55.1
 numpy==1.21.5
 scipy==1.8.0

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -96,7 +96,7 @@ def hermite_multidimensional(
     Rt = np.real_if_close(R)
     yt = np.real_if_close(y)
 
-    dtype = np.find_common_type([Rt.dtype.name, yt.dtype.name], [np.array(C).dtype.name])
+    dtype = np.result_type(Rt, yt, C)
     array = np.zeros(cutoffs, dtype=dtype)
     array[(0,) * num_indices] = C
 
@@ -153,7 +153,7 @@ def interferometer(R, cutoff, C=1, renorm=True, make_tensor=True, rtol=1e-05, at
 
     Rt = np.real_if_close(R)
 
-    dtype = np.find_common_type([Rt.dtype.name], [np.array(C).dtype.name])
+    dtype = np.result_type(Rt, C)
     array = np.zeros(cutoffs, dtype=dtype)
     array[(0,) * num_indices] = C
 
@@ -400,9 +400,7 @@ def grad_hermite_multidimensional(G, R, y, C=1, renorm=True, dtype=None):
         array[data type], array[data type], array[data type]: the gradients of the multidimensional Hermite polynomials with respect to C, R and y
     """
     if dtype is None:
-        dtype = np.find_common_type(
-            [G.dtype.name, R.dtype.name, y.dtype.name], [np.array(C).dtype.name]
-        )
+        dtype = np.result_type(G, R, y, C)
     n, _ = R.shape
     if y.shape[0] != n:
         raise ValueError(

--- a/thewalrus/_hermite_multidimensional.py
+++ b/thewalrus/_hermite_multidimensional.py
@@ -231,7 +231,7 @@ def dec(tup: Tuple[int], i: int) -> Tuple[int, ...]:  # pragma: no cover
 
 @jit(nopython=True)
 def remove(
-    pattern: Tuple[int, ...]
+    pattern: Tuple[int, ...],
 ) -> Generator[Tuple[int, Tuple[int, ...]], None, None]:  # pragma: no cover
     r"""returns a generator for all the possible ways to decrease elements of the given tuple by 1
     Args:

--- a/thewalrus/_low_rank_haf.py
+++ b/thewalrus/_low_rank_haf.py
@@ -83,6 +83,6 @@ def low_rank_hafnian(G):
         facts = 1
         for i, pi in enumerate(c):
             monomial *= x[i] ** (2 * pi)
-            facts = facts * factorial2(2 * pi - 1)
+            facts = facts * factorial2(2 * pi - 1, extend="complex")
         haf_val += complex(poly.coeff(monomial) * facts)
     return haf_val

--- a/thewalrus/_low_rank_haf.py
+++ b/thewalrus/_low_rank_haf.py
@@ -67,7 +67,7 @@ def low_rank_hafnian(G):
     if n % 2 != 0:
         return 0
     if r == 1:
-        return factorial2(n - 1) * np.prod(G)
+        return factorial2(n - 1, extend="complex") * np.prod(G)
     poly = 1
     x = symbols("x0:" + str(r))
     for k in range(n):

--- a/thewalrus/_montrealer.py
+++ b/thewalrus/_montrealer.py
@@ -4,6 +4,7 @@ Montrealer Python interface
 * See Yanic Cardin and Nicolás Quesada. "Photon-number moments and cumulants of Gaussian states"
   `arxiv:12212.06067 (2023) <https://arxiv.org/abs/2212.06067>`_ :cite:`cardin2022photon`
 """
+
 import numpy as np
 import numba
 from thewalrus.quantum.conversions import Xmat

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Version information.
-   Version number (major.minor.patch[-label])
+Version number (major.minor.patch[-label])
 """
 
 __version__ = "0.22.0-dev"

--- a/thewalrus/fock_gradients.py
+++ b/thewalrus/fock_gradients.py
@@ -25,16 +25,16 @@ Summary
 -------
 
 .. autosummary::
-	displacement
-	squeezing
-	beamsplitter
-	two_mode_squeezing
-	mzgate
-	grad_displacement
-	grad_squeezing
-	grad_beamsplitter
-	grad_two_mode_squeezing
-	grad_mzgate
+        displacement
+        squeezing
+        beamsplitter
+        two_mode_squeezing
+        mzgate
+        grad_displacement
+        grad_squeezing
+        grad_beamsplitter
+        grad_two_mode_squeezing
+        grad_mzgate
 
 Code details
 ------------

--- a/thewalrus/grouped_click_probabilities.py
+++ b/thewalrus/grouped_click_probabilities.py
@@ -1,4 +1,5 @@
 """Functions for computing grouped click probabilities"""
+
 import numpy as np
 from numba import jit
 

--- a/thewalrus/tests/test_grouped_click_probabilities.py
+++ b/thewalrus/tests/test_grouped_click_probabilities.py
@@ -1,4 +1,5 @@
 """Test for the grouped click probability function"""
+
 from itertools import product
 import numpy as np
 import pytest

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for The Walrus quantum functions"""
 # pylint: disable=no-self-use,redefined-outer-name
+import math
 from itertools import product
 
 import pytest
@@ -586,7 +587,7 @@ def test_pure_state_amplitude_two_mode_squeezed(i, j):
     phase = np.pi / 8
     r = np.arcsinh(np.sqrt(nbar))
     cov = two_mode_squeezing(2 * r, phase)
-    mu = np.zeros([4], dtype=np.complex)
+    mu = np.zeros([4], dtype=complex)
     if i != j:
         exact = 0.0
     else:
@@ -603,7 +604,7 @@ def test_pure_state_amplitude_coherent(i):
     mu = np.array([1.0, 2.0])
     beta = complex_to_real_displacements(mu)
     alpha = beta[0]
-    exact = np.exp(-0.5 * np.abs(alpha) ** 2) * alpha**i / np.sqrt(np.math.factorial(i))
+    exact = np.exp(-0.5 * np.abs(alpha) ** 2) * alpha**i / np.sqrt(math.factorial(i))
     num = pure_state_amplitude(mu, cov, [i])
     assert np.allclose(exact, num)
 
@@ -700,7 +701,7 @@ def test_state_vector_two_mode_squeezed():
     phase = np.pi / 8
     r = np.arcsinh(np.sqrt(nbar))
     cov = two_mode_squeezing(2 * r, phase)
-    mu = np.zeros([4], dtype=np.complex)
+    mu = np.zeros([4], dtype=complex)
     exact = np.array(
         [
             (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
@@ -719,7 +720,7 @@ def test_state_vector_two_mode_squeezed_post():
     phase = np.pi / 8
     r = np.arcsinh(np.sqrt(nbar))
     cov = two_mode_squeezing(2 * r, phase)
-    mu = np.zeros([4], dtype=np.complex)
+    mu = np.zeros([4], dtype=complex)
     exact = np.diag(
         np.array(
             [
@@ -744,7 +745,7 @@ def test_state_vector_coherent():
     alpha = beta[0]
     exact = np.array(
         [
-            (np.exp(-0.5 * np.abs(alpha) ** 2) * alpha**i / np.sqrt(np.math.factorial(i)))
+            (np.exp(-0.5 * np.abs(alpha) ** 2) * alpha**i / np.sqrt(math.factorial(i)))
             for i in range(cutoff)
         ]
     )
@@ -759,7 +760,7 @@ def test_state_vector_two_mode_squeezed_post_normalize():
     phase = np.pi / 8
     r = np.arcsinh(np.sqrt(nbar))
     cov = two_mode_squeezing(2 * r, phase)
-    mu = np.zeros([4], dtype=np.complex)
+    mu = np.zeros([4], dtype=complex)
     exact = np.diag(
         np.array(
             [
@@ -1214,7 +1215,7 @@ def test_loss_is_nonnegative_matrix(eta):
     """Test the loss matrix is a nonnegative matrix"""
     n = 50
     M = loss_mat(eta, n)
-    assert np.alltrue(M >= 0.0)
+    assert np.all(M >= 0.0)
 
 
 @pytest.mark.parametrize("eta", [-1.0, 2.0])
@@ -1762,8 +1763,8 @@ def test_marginal_probs_are_normalized():
 
     result = n_body_marginals(means, cov, cutoff, 3)
     for tensor in result:
-        assert np.alltrue(np.round(tensor, 14) >= 0.0)
-        assert np.alltrue(tensor <= 1.0)
+        assert np.all(np.round(tensor, 14) >= 0.0)
+        assert np.all(tensor <= 1.0)
 
 
 def test_correct_indexing_n_body_marginals():

--- a/thewalrus/tests/test_reference.py
+++ b/thewalrus/tests/test_reference.py
@@ -47,7 +47,7 @@ class TestReferenceHafnian:
         r"""Checks that the hafnian of the all ones matrix of size n is (n-1)!!"""
         M = np.ones([n, n])
         if n % 2 == 0:
-            assert np.allclose(factorial2(n - 1), hafnian(M))
+            assert np.allclose(factorial2(n - 1, extend="complex"), hafnian(M))
         else:
             assert np.allclose(0, hafnian(M))
 

--- a/thewalrus/tests/test_samples.py
+++ b/thewalrus/tests/test_samples.py
@@ -89,7 +89,7 @@ class TestHafnianSampling:
     def test_hafnian_sample_states_nans(self):
         """test exception is raised if not a numpy array"""
         with pytest.raises(ValueError, match="Covariance matrix must not contain NaNs."):
-            hafnian_sample_state(np.array([[0, 5], [0, np.NaN]]), samples=20)
+            hafnian_sample_state(np.array([[0, 5], [0, np.nan]]), samples=20)
 
     def test_single_squeezed_state_hafnian(self):
         """Test the sampling routines by comparing the photon number frequencies and the exact
@@ -293,7 +293,7 @@ class TestHafnianSampling:
         n_samples = 100
         n_modes = 10
         sigma = np.identity(2 * n_modes)
-        zeros = np.zeros(n_modes, dtype=np.int)
+        zeros = np.zeros(n_modes, dtype=int)
         samples = sample_func(
             sigma, samples=n_samples
         )  # hafnian_sample_classical_state(sigma, samples=n_samples)
@@ -342,7 +342,7 @@ class TestTorontonianSampling:
     def test_torontonian_samples_nans(self):
         """test exception is raised if not a numpy array"""
         with pytest.raises(ValueError, match="Covariance matrix must not contain NaNs."):
-            torontonian_sample_state(np.array([[0, 5], [0, np.NaN]]), samples=20)
+            torontonian_sample_state(np.array([[0, 5], [0, np.nan]]), samples=20)
 
     def test_single_squeezed_state_torontonian(self):
         """Test the sampling routines by comparing the photon number frequencies and the exact
@@ -419,7 +419,7 @@ class TestTorontonianSampling:
         n_samples = 100
         n_modes = 10
         sigma = np.identity(2 * n_modes)
-        zeros = np.zeros(n_modes, dtype=np.int)
+        zeros = np.zeros(n_modes, dtype=int)
         samples = sample_func(sigma, samples=n_samples)
         for i in range(n_samples):
             assert np.all(samples[i] == zeros)


### PR DESCRIPTION
**Context:**
Attempts to get `thewalrus` working with newer versions of `numpy`.

**Description of the Change:**
Edits files, in particular moving from `numpy.int` to `int`, `numpy.complex` to `complex`, `numpy.math` to `math`, and `numpy.find_common_type` to `numpy.result_type`.

**Benefits:**
`thewalrus` will continue to work with newer versions of `numpy`

**Possible Drawbacks:**
May want/need to ensure that `thewalrus` stays backwards compatible with earlier versions of `numpy`.

**Related GitHub Issues:**
