### PR TITLE
Use `numpy.emath.sqrt`

### DIFF
--- a/thewalrus/samples.py
+++ b/thewalrus/samples.py
@@ -108,8 +108,8 @@ def decompose_cov(cov):
     D, S = williamson(cov)
     T = S @ S.T
     DmI = D - np.eye(2 * m)
-    DmI[abs(DmI) < 1e-11] = 0.0  # remove slightly negative values
-    sqrtW = S @ np.sqrt(DmI)
+    DmI[abs(DmI) < 1e-11] = 0.0  # remove small values
+    sqrtW = S @ np.emath.sqrt(DmI)
     return T, sqrtW
 
 


### PR DESCRIPTION
**Context:**
There seem to be some covariance matrices for which `thewalrus.samples.decompose_cov` returns all `nan`s for `sqrtW`. The following is one such example:
```python
np.array(
    [
        [0.9256, 0.0893, 0.0000, 0.1055, 0.0000, 0.1246, 0.0000, 0.0000, 0.0000, 0.1972, 0.0000, 0.2329, 0.0000, 0.2752],
        [0.0893, 0.9555, 0.0000, 0.1246, 0.0000, 0.1472, 0.0000, 0.0000, 0.0000, 0.2329, 0.0000, 0.2752, 0.0000, 0.3251],
        [0.0000, 0.0000, 0.9729, 0.0000, 0.1452, 0.0000, 0.1715, 0.1972, 0.2329, 0.0000, 0.2752, 0.0000, 0.3251, 0.0000],
        [0.1055, 0.1246, 0.0000, 0.9972, 0.0000, 0.1739, 0.0000, 0.0000, 0.0000, 0.2752, 0.0000, 0.3251, 0.0000, 0.3840],
        [0.0000, 0.0000, 0.1452, 0.0000, 1.0215, 0.0000, 0.2026, 0.2329, 0.2752, 0.0000, 0.3251, 0.0000, 0.3840, 0.0000],
        [0.1246, 0.1472, 0.0000, 0.1739, 0.0000, 1.0555, 0.0000, 0.0000, 0.0000, 0.3251, 0.0000, 0.3840, 0.0000, 0.4537],
        [0.0000, 0.0000, 0.1715, 0.0000, 0.2026, 0.0000, 1.0894, 0.2752, 0.3251, 0.0000, 0.3840, 0.0000, 0.4537, 0.0000],
        [0.0000, 0.0000, 0.1972, 0.0000, 0.2329, 0.0000, 0.2752, 0.9256, 0.0893, 0.0000, 0.1055, 0.0000, 0.1246, 0.0000],
        [0.0000, 0.0000, 0.2329, 0.0000, 0.2752, 0.0000, 0.3251, 0.0893, 0.9555, 0.0000, 0.1246, 0.0000, 0.1472, 0.0000],
        [0.1972, 0.2329, 0.0000, 0.2752, 0.0000, 0.3251, 0.0000, 0.0000, 0.0000, 0.9729, 0.0000, 0.1452, 0.0000, 0.1715],
        [0.0000, 0.0000, 0.2752, 0.0000, 0.3251, 0.0000, 0.3840, 0.1055, 0.1246, 0.0000, 0.9972, 0.0000, 0.1739, 0.0000],
        [0.2329, 0.2752, 0.0000, 0.3251, 0.0000, 0.3840, 0.0000, 0.0000, 0.0000, 0.1452, 0.0000, 1.0215, 0.0000, 0.2026],
        [0.0000, 0.0000, 0.3251, 0.0000, 0.3840, 0.0000, 0.4537, 0.1246, 0.1472, 0.0000, 0.1739, 0.0000, 1.0555, 0.0000],
        [0.2752, 0.3251, 0.0000, 0.3840, 0.0000, 0.4537, 0.0000, 0.0000, 0.0000, 0.1715, 0.0000, 0.2026, 0.0000, 1.0894],
    ]
)
```

**Description of the Change:**
Changes the `np.sqrt` to `np.emath.sqrt` in `thewalrus.samples.decompose_cov` to properly take the square root when dealing with negative reals.

**Benefits:**
`thewalrus.samples.decompose_cov` can deal with a larger set of covariance matrices

**Possible Drawbacks:**
None?

**Related GitHub Issues:**
N/A