### PR TITLE
0.23.0-dev

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Release 0.23.0-dev
+
+### New features
+
+### Breaking changes
+
+### Improvements
+
+### Bug fixes
+
+### Documentation
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+---
+
 # Release 0.22.0
 
 ### New features

--- a/.github/workflows/tests_full.yml
+++ b/.github/workflows/tests_full.yml
@@ -1,12 +1,19 @@
-name: tests
+name: tests_full
 on:
-  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
-  python-tests-pr:
-    name: python
-    if: github.event.pull_request.merged != true
-    runs-on: ubuntu-latest
+  python-tests-merged:
+    name: python-master
+    if: github.event.pull_request.merged ==true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12']
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Cancel Previous Runs
@@ -20,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         shell: bash

--- a/thewalrus/_version.py
+++ b/thewalrus/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.22.0"
+__version__ = "0.23.0-dev"


### PR DESCRIPTION
**Context:**
Having just merged the branch that updated the version and CHANGELOG from `0.22.0-dev` to `0.22.0`, we are now ready for the next version.

**Description of the Change:**
Updates the version and CHANGELOG entry to `0.23.0-dev`.

**Benefits:**
No risk of confusion about the current version.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
N/A