### PR TITLE
Fix computation of Takagi unitary

### DIFF
--- a/.github/ACKNOWLEDGMENTS.md
+++ b/.github/ACKNOWLEDGMENTS.md
@@ -71,3 +71,5 @@
 * [Yanic Cardin](https://github.com/yaniccd) (Polytechnique Montréal) - 🦜 Pirate of the permutations
 
 * [Tom Dodd](https://github.com/tomdodd4598) (University of Edinburgh) - 🕴️ Agent Root
+
+* [Arsalan Motamedi](https://github.com/arsalan-motamedi) (Xanadu) - 🧭 Phase Shifter

--- a/.github/ACKNOWLEDGMENTS.md
+++ b/.github/ACKNOWLEDGMENTS.md
@@ -69,3 +69,5 @@
 * Will McCutcheon (Heriot-Watt University) - 🧅 Gaussian Onion Merchant
 
 * [Yanic Cardin](https://github.com/yaniccd) (Polytechnique Montréal) - 🦜 Pirate of the permutations
+
+* [Tom Dodd](https://github.com/tomdodd4598) (University of Edinburgh) - 🕴️ Agent Root

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Adds hbar to `decompose_cov`, so that it does not always silently assume hbar=2 even when working with quantum covariance matrices generated with hbar!=2 [(#402)](https://github.com/XanaduAI/thewalrus/pull/402).
 
-* Fixed bug in `takagi` which incorrectly computed the unitary W matrix. [#403](https://github.com/XanaduAI/thewalrus/pull/403)
+* Fixes bug in `takagi` which incorrectly computed the unitary W matrix. [#403](https://github.com/XanaduAI/thewalrus/pull/403)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-T.H. Dodd, L.G. Helt
+T.H. Dodd, L.G. Helt, A. Motamedi
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -10,13 +10,15 @@
 
 * Adds hbar to `decompose_cov`, so that it does not always silently assume hbar=2 even when working with quantum covariance matrices generated with hbar!=2 [(#402)](https://github.com/XanaduAI/thewalrus/pull/402).
 
+* Fixed bug in `takagi` which incorrectly computed the unitary W matrix. [#403](https://github.com/XanaduAI/thewalrus/pull/403)
+
 ### Documentation
 
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
-L.G. Helt
+T.H. Dodd, L.G. Helt
 
 ---
 

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -152,7 +152,7 @@ def blochmessiah(S):
     return O, D, Q
 
 
-def takagi(A, svd_order=True, rtol=1e-16, random_seed=None):
+def takagi(A, svd_order=True, rtol=1e-16):
     # pylint: disable=too-many-return-statements
     r"""Autonne-Takagi decomposition of a complex symmetric (not Hermitian!) matrix.
     Note that the input matrix is internally symmetrized by taking its upper triangular part.
@@ -164,8 +164,6 @@ def takagi(A, svd_order=True, rtol=1e-16, random_seed=None):
         A (array): square, symmetric matrix
         svd_order (boolean): whether to return result by ordering the singular values of ``A`` in descending (``True``) or ascending (``False``) order.
         rtol (float): the relative tolerance parameter used in ``np.allclose`` when judging if the matrix is diagonal or not. Default to 1e-16.
-        random_seed (None | int): the seed for the RNG used to generate random phases which avoid numerical inaccuracies of the matrix square root
-            by moving elements away from a complex argument very close to ±π. Defaults to None.
 
     Returns:
         tuple[array, array]: (r, U), where r are the singular values,

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -218,7 +218,7 @@ def takagi(A, svd_order=True, rtol=1e-16):
         return l, U
 
     u, d, v = np.linalg.svd(A)
-    U = u @ sqrtm((v @ np.conjugate(u)).T)
+    U = u @ sqrtm((u.T @ v).conj())
     if svd_order is False:
         return d[::-1], U[:, ::-1]
     return d, U

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -217,8 +217,10 @@ def takagi(A, svd_order=True, rtol=1e-16):
             return l[::-1], U[:, ::-1]
         return l, U
 
-    u, d, v = np.linalg.svd(A)
-    U = u @ sqrtm((u.T @ v).conj())
+    u, d, vh = np.linalg.svd(A)
+    s = sqrtm(vh @ u.conj()).astype(np.complex128)
+    y, _, zh = np.linalg.svd(s)
+    U = u @ y @ zh
     if svd_order is False:
         return d[::-1], U[:, ::-1]
     return d, U

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -152,7 +152,7 @@ def blochmessiah(S):
     return O, D, Q
 
 
-def takagi(A, svd_order=True, rtol=1e-16):
+def takagi(A, svd_order=True, rtol=1e-16, max_iter=10):
     # pylint: disable=too-many-return-statements
     r"""Autonne-Takagi decomposition of a complex symmetric (not Hermitian!) matrix.
     Note that the input matrix is internally symmetrized by taking its upper triangular part.
@@ -164,6 +164,8 @@ def takagi(A, svd_order=True, rtol=1e-16):
         A (array): square, symmetric matrix
         svd_order (boolean): whether to return result by ordering the singular values of ``A`` in descending (``True``) or ascending (``False``) order.
         rtol (float): the relative tolerance parameter used in ``np.allclose`` when judging if the matrix is diagonal or not. Default to 1e-16.
+        max_iter (int): the maximum number of iterations to use while attempting to correct the error of the general decomposition caused by the matrix
+            square-root. Defaults to 10.
 
     Returns:
         tuple[array, array]: (r, U), where r are the singular values,
@@ -217,10 +219,34 @@ def takagi(A, svd_order=True, rtol=1e-16):
             return l[::-1], U[:, ::-1]
         return l, U
 
+    # Fix non-unitary sqrt via second SVD
     u, d, vh = np.linalg.svd(A)
     s = sqrtm(vh @ u.conj()).astype(np.complex128)
     y, _, zh = np.linalg.svd(s)
     U = u @ y @ zh
+
+    # Iteratively correct d, U until error is small or not decreasing
+    prev_err, prev_d, prev_U = np.inf, d, U
+    for _ in range(max_iter):
+        # Break if close to correct
+        diff = A - U @ np.diag(d) @ U.T
+        if np.allclose(diff, 0):
+            break
+
+        U_conj = U.conj()
+        u, d, vh = np.linalg.svd(U_conj.T @ A @ U_conj)
+        s = sqrtm(vh @ u.conj()).astype(np.complex128)
+        y, _, zh = np.linalg.svd(s)
+        W = u @ y @ zh
+        U @= W
+
+        # Break if previous error is lower
+        curr_err = np.max(np.abs(diff))
+        if prev_err <= curr_err:
+            d, U = prev_d, prev_U
+            break
+        prev_err, prev_d, prev_U = curr_err, d, U
+
     if svd_order is False:
         return d[::-1], U[:, ::-1]
     return d, U

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -230,7 +230,7 @@ def takagi(A, svd_order=True, rtol=1e-16):
     # Rotate z to shift midpoint of largest arc to ±pi
     shift_angle = np.ones(n) * shift_angle
     z @= np.diag(np.exp(1j * shift_angle))
-    # Undo rotation from ±π
+    # Undo rotation from ±pi
     U = u @ sqrtm(z) @ np.diag(np.exp(-0.5j * shift_angle))
     if svd_order is False:
         return d[::-1], U[:, ::-1]

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -225,7 +225,7 @@ def takagi(A, svd_order=True, rtol=1e-16):
     z_diffs = np.diff(z_angles, append=z_angles[0] + 2 * np.pi)
     idx = np.argmax(z_diffs)
     mid = z_angles[idx] + 0.5 * z_diffs[idx]
-    # Get shift angle in (-π, π]
+    # Get shift angle in (-pi, pi]
     shift_angle = np.mod(-mid, 2 * np.pi) - np.pi
     # Rotate z to shift midpoint of largest arc to ±π
     shift_angle = np.ones(n) * shift_angle

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -219,19 +219,22 @@ def takagi(A, svd_order=True, rtol=1e-16):
 
     u, d, vh = np.linalg.svd(A)
     z = vh @ u.conj()
+    T, Q = schur(z, output='complex')
+    z_eigvals = np.diag(T)
     # Get sorted z angles in [0, 2π)
-    z_angles = np.sort(np.unique(np.mod(np.angle(np.linalg.eigvals(z)), 2 * np.pi)))
+    z_angles = np.sort(np.unique(np.mod(np.angle(z_eigvals), 2 * np.pi)))
     # Get midpoint of largest arc
     z_diffs = np.diff(z_angles, append=z_angles[0] + 2 * np.pi)
     idx = np.argmax(z_diffs)
     mid = z_angles[idx] + 0.5 * z_diffs[idx]
     # Get shift angle in (-pi, pi]
     shift_angle = np.mod(-mid, 2 * np.pi) - np.pi
-    # Rotate z to shift midpoint of largest arc to ±pi
-    shift_angle = np.ones(n) * shift_angle
-    z @= np.diag(np.exp(1j * shift_angle))
+    # Rotate eigenvalues to shift midpoint of largest arc to ±pi
+    z_eigvals_shifted = z_eigvals * np.exp(1j * shift_angle)
+    sqrt_z_eigvals_shifted = np.sqrt(z_eigvals_shifted)
+    sqrt_z_shifted = Q @ np.diag(sqrt_z_eigvals_shifted) @ Q.conj().T
     # Undo rotation from ±pi
-    U = u @ sqrtm(z) @ np.diag(np.exp(-0.5j * shift_angle))
+    U = u @ sqrt_z_shifted @ np.diag(np.exp(-0.5j * shift_angle * np.ones(n)))
     if svd_order is False:
         return d[::-1], U[:, ::-1]
     return d, U

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -219,7 +219,7 @@ def takagi(A, svd_order=True, rtol=1e-16):
 
     u, d, vh = np.linalg.svd(A)
     z = vh @ u.conj()
-    T, Q = schur(z, output='complex')
+    T, Q = schur(z, output="complex")
     z_eigvals = np.diag(T)
     # Get sorted z angles in [0, 2π)
     z_angles = np.sort(np.unique(np.mod(np.angle(z_eigvals), 2 * np.pi)))

--- a/thewalrus/decompositions.py
+++ b/thewalrus/decompositions.py
@@ -227,7 +227,7 @@ def takagi(A, svd_order=True, rtol=1e-16):
     mid = z_angles[idx] + 0.5 * z_diffs[idx]
     # Get shift angle in (-pi, pi]
     shift_angle = np.mod(-mid, 2 * np.pi) - np.pi
-    # Rotate z to shift midpoint of largest arc to ±π
+    # Rotate z to shift midpoint of largest arc to ±pi
     shift_angle = np.ones(n) * shift_angle
     z @= np.diag(np.exp(1j * shift_angle))
     # Undo rotation from ±π

--- a/thewalrus/tests/test_decompositions.py
+++ b/thewalrus/tests/test_decompositions.py
@@ -256,16 +256,16 @@ class TestBlochMessiahDecomposition:
 
 
 @pytest.mark.parametrize("n", [5, 10, 50])
-@pytest.mark.parametrize("datatype", [np.complex128, np.float64])
+@pytest.mark.parametrize("imag_part", [0, 1e-10, 1])
 @pytest.mark.parametrize("svd_order", [True, False])
-def test_takagi(n, datatype, svd_order):
-    """Checks the correctness of the Takagi decomposition function"""
-    if datatype is np.complex128:
-        A = np.random.rand(n, n) + 1j * np.random.rand(n, n)
-    if datatype is np.float64:
-        A = np.random.rand(n, n)
+def test_takagi(n, imag_part, svd_order):
+    """Checks the correctness of the Takagi decomposition function for generic random matrices"""
+    A = np.random.rand(n, n)
+    if imag_part > 0:
+         A = A + 1j * imag_part * np.random.rand(n, n)
     A += A.T
     r, U = takagi(A, svd_order=svd_order)
+    assert np.allclose(np.eye(n, n), U @ U.T.conj())
     assert np.allclose(A, U @ np.diag(r) @ U.T)
     assert np.all(r >= 0)
     if svd_order is True:

--- a/thewalrus/tests/test_decompositions.py
+++ b/thewalrus/tests/test_decompositions.py
@@ -262,7 +262,7 @@ def test_takagi(n, imag_part, svd_order):
     """Checks the correctness of the Takagi decomposition function for generic random matrices"""
     A = np.random.rand(n, n)
     if imag_part > 0:
-         A = A + 1j * imag_part * np.random.rand(n, n)
+        A = A + 1j * imag_part * np.random.rand(n, n)
     A += A.T
     r, U = takagi(A, svd_order=svd_order)
     assert np.allclose(np.eye(n, n), U @ U.T.conj())


### PR DESCRIPTION
**Context:**
1. The current computation of the W matrix in `takagi` does not always produce a unitary matrix (up to floating point noise). The cause seems to be the existence of eigenvalues of the matrix to be square-rooted very close to the branch cut of the complex square root through an angle of ±π. We avoid this source of inaccuracy by temporarily adding an additional phase to the matrix which best clears the branch cut of any eigenvalues, computing the square root, and then removing half of the same phase.

2. (Not important as discussed below) The current implementation uses `(vh @ np.conjugate(u)).T` in the matrix square root, when the correct expression to use seems to be `(u.T @ vh).conj()` = `vh @ u.conj()` as shown in box 1 on page 5 of the [paper](https://arxiv.org/pdf/2403.04596) referenced in the docstring.

An example of the current implementation failing can be found [here](https://gist.github.com/tomdodd4598/f1b42a1c491c43c7661b90685160496b).

**Description of the Change:**
Improve the current general-case Takagi decomposition algorithm.

**Benefits:**
Makes `takagi` correctly return unitary matrix.