### PR TITLE
custom dimensions for a multimode density matrix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,25 @@
+# Release 0.24.0-dev
+
+### New features
+
+### Breaking changes
+
+### Improvements
+
+### Bug fixes
+
+* Adds support of the 'list' type of 'cutoff' argument for the 'density_matrix(mu, cov, post_select, normalize, cutoff, hbar)' function from 'fock_tensors.py'. It enables to perform larger simulations by decreasing required RAM.[(#406)](https://github.com/XanaduAI/thewalrus/pull/406).
+
+### Documentation
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+Ivan Solomakhin
+
+---
+
 # Release 0.23.0-dev
 
 ### New features

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,25 +1,3 @@
-# Release 0.24.0-dev
-
-### New features
-
-### Breaking changes
-
-### Improvements
-
-### Bug fixes
-
-* Adds support of the 'list' type of 'cutoff' argument for the 'density_matrix(mu, cov, post_select, normalize, cutoff, hbar)' function from 'fock_tensors.py'. It enables to perform larger simulations by decreasing required RAM.[(#406)](https://github.com/XanaduAI/thewalrus/pull/406).
-
-### Documentation
-
-### Contributors
-
-This release contains contributions from (in alphabetical order):
-
-Ivan Solomakhin
-
----
-
 # Release 0.23.0-dev
 
 ### New features
@@ -29,6 +7,7 @@ Ivan Solomakhin
 ### Improvements
 
 * Improved speed of `_hermite_multidimensional_renorm` by 4x [(#404)](https://github.com/XanaduAI/thewalrus/pull/404).
+* Adds support of the 'list' type of 'cutoff' argument for the 'density_matrix(mu, cov, post_select, normalize, cutoff, hbar)' function from 'fock_tensors.py'. It enables to perform larger simulations by decreasing required RAM [(#406)](https://github.com/XanaduAI/thewalrus/pull/406).
 
 ### Bug fixes
 
@@ -40,7 +19,7 @@ Ivan Solomakhin
 
 This release contains contributions from (in alphabetical order):
 
-L.G. Helt, F. Miatto
+L.G. Helt, F. Miatto, Ivan Solomakhin
 
 ---
 

--- a/thewalrus/quantum/fock_tensors.py
+++ b/thewalrus/quantum/fock_tensors.py
@@ -257,8 +257,9 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
             is calculated directly using (multidimensional) Hermite polynomials, which is significantly faster
             than calculating one hafnian at a time.
         normalize (bool): If ``True``, a post-selected density matrix is re-normalized.
-        cutoff (dim): the final length (i.e., Hilbert space dimension) of each
-            mode in the density matrix.
+        cutoff (list[int] or int): the final length (i.e., Hilbert space dimension) of each
+            mode in the density matrix. if int, all modes have the same final length. If list[int], each mode can have
+            a custom final length
         hbar (float): the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`.
 
@@ -266,6 +267,8 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
         np.array[complex]: the density matrix of the Gaussian state
     """
     N = len(mu) // 2
+    if type(cutoff) is int:
+        cutoff = [cutoff] * N
     pref = _prefactor(mu, cov, hbar=hbar)
 
     if post_select is None:
@@ -273,17 +276,18 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
         sf_order = tuple(chain.from_iterable([[i, i + N] for i in range(N)]))
 
         if np.allclose(mu, np.zeros_like(mu)):
-            tensor = pref * hermite_multidimensional(-A, cutoff, renorm=True, modified=True)
+            tensor = pref * hermite_multidimensional(-A, [idx for _ in range(2)  for idx in cutoff], renorm=True, modified=True)
             return tensor.transpose(sf_order)
         beta = complex_to_real_displacements(mu, hbar=hbar)
         y = beta - A @ beta.conj()
-        tensor = pref * hermite_multidimensional(-A, cutoff, y=y, renorm=True, modified=True)
+        tensor = pref * hermite_multidimensional(-A, [idx for _ in range(2)  for idx in cutoff], y=y, renorm=True, modified=True)
         return tensor.transpose(sf_order)
 
     M = N - len(post_select)
-    rho = np.zeros([cutoff] * (2 * M), dtype=np.complex128)
+    cutoff = [cutoff[i] for i in range(N) if not (i in post_select)]
+    rho = np.zeros([elem for _ in range(2) for elem in cutoff], dtype=np.complex128)
 
-    for idx in product(range(cutoff), repeat=2 * M):
+    for idx in product(*[range(n) for n in cutoff], repeat=2):
         el = []
 
         counter = count(0)
@@ -304,7 +308,8 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
     if normalize:
         # construct the standard 2D density matrix, and take the trace
         new_ax = np.arange(2 * M).reshape([M, 2]).T.flatten()
-        tr = np.trace(rho.transpose(new_ax).reshape([cutoff**M, cutoff**M])).real
+        rho = rho.transpose(new_ax).reshape([np.prod(cutoff), np.prod(cutoff)])
+        tr = np.trace(rho).real
         # renormalize
         rho /= tr
 

--- a/thewalrus/quantum/fock_tensors.py
+++ b/thewalrus/quantum/fock_tensors.py
@@ -46,9 +46,7 @@ from .conversions import (
 from .gaussian_checks import is_classical_cov, is_pure_cov, is_valid_cov
 
 
-def pure_state_amplitude(
-    mu, cov, i, include_prefactor=True, tol=1e-10, hbar=2, check_purity=True
-):
+def pure_state_amplitude(mu, cov, i, include_prefactor=True, tol=1e-10, hbar=2, check_purity=True):
     r"""Returns the :math:`\langle i | \psi\rangle` element of the state ket
     of a Gaussian state defined by covariance matrix cov.
 
@@ -70,9 +68,7 @@ def pure_state_amplitude(
     """
     if check_purity:
         if not is_pure_cov(cov, hbar=hbar, rtol=1e-05, atol=1e-08):
-            raise ValueError(
-                "The covariance matrix does not correspond to a pure state"
-            )
+            raise ValueError("The covariance matrix does not correspond to a pure state")
 
     rpt = i
     beta = complex_to_real_displacements(mu, hbar=hbar)
@@ -100,23 +96,14 @@ def pure_state_amplitude(
             haf = hafnian_repeated(B, rpt, mu=gamma, loop=True)
 
     if include_prefactor:
-        pref = np.exp(
-            -0.5 * (np.linalg.norm(alpha) ** 2 - alpha.conj() @ B @ alpha.conj())
-        )
+        pref = np.exp(-0.5 * (np.linalg.norm(alpha) ** 2 - alpha.conj() @ B @ alpha.conj()))
         haf *= pref
 
     return haf / np.sqrt(np.prod(fac(rpt)) * np.sqrt(np.linalg.det(Q)))
 
 
 def state_vector(
-    mu,
-    cov,
-    post_select=None,
-    normalize=False,
-    cutoff=5,
-    hbar=2,
-    check_purity=True,
-    **kwargs
+    mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2, check_purity=True, **kwargs
 ):
     r"""Returns the state vector of a (PNR post-selected) Gaussian state.
 
@@ -155,9 +142,7 @@ def state_vector(
     """
     if check_purity:
         if not is_pure_cov(cov, hbar=hbar, rtol=1e-05, atol=1e-08):
-            raise ValueError(
-                "The covariance matrix does not correspond to a pure state"
-            )
+            raise ValueError("The covariance matrix does not correspond to a pure state")
 
     beta = complex_to_real_displacements(mu, hbar=hbar)
     A = Amat(cov, hbar=hbar)
@@ -183,11 +168,7 @@ def state_vector(
             gamma = rescaling * gamma
             denom = np.sqrt(np.sqrt(np.linalg.det(Q / np.cosh(choi_r)).real))
 
-        psi = (
-            pref
-            * hafnian_batched(B.conj(), cutoff, mu=gamma.conj(), renorm=True)
-            / denom
-        )
+        psi = pref * hafnian_batched(B.conj(), cutoff, mu=gamma.conj(), renorm=True) / denom
     else:
         M = N - len(post_select)
         psi = np.zeros([cutoff] * (M), dtype=np.complex128)
@@ -197,10 +178,7 @@ def state_vector(
 
             counter = count(0)
             modes = (np.arange(N)).tolist()
-            el = [
-                post_select[i] if i in post_select else idx[next(counter)]
-                for i in modes
-            ]
+            el = [post_select[i] if i in post_select else idx[next(counter)] for i in modes]
             psi[idx] = pure_state_amplitude(
                 mu, cov, el, check_purity=False, include_prefactor=False, hbar=hbar
             )
@@ -331,9 +309,7 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
         sf_idx = np.array(idx).reshape(2, -1)
         sf_el = tuple(sf_idx[::-1].T.flatten())
 
-        rho[sf_el] = density_matrix_element(
-            mu, cov, el0, el1, include_prefactor=False, hbar=hbar
-        )
+        rho[sf_el] = density_matrix_element(mu, cov, el0, el1, include_prefactor=False, hbar=hbar)
 
     rho *= pref
 
@@ -384,9 +360,7 @@ def fock_tensor(
     m, _ = S.shape
     l = m // 2
     if l != len(alpha):
-        raise ValueError(
-            "The matrix S and the vector alpha do not have compatible dimensions"
-        )
+        raise ValueError("The matrix S and the vector alpha do not have compatible dimensions")
     # Check if S corresponds to an interferometer, if so use optimized routines
     if np.allclose(S @ S.T, np.identity(m), rtol=rtol, atol=atol) and np.allclose(
         alpha, 0, rtol=rtol, atol=atol
@@ -401,9 +375,7 @@ def fock_tensor(
         ch = np.cosh(choi_r) * np.identity(l)
         sh = np.sinh(choi_r) * np.identity(l)
         zh = np.zeros([l, l])
-        Schoi = np.block(
-            [[ch, sh, zh, zh], [sh, ch, zh, zh], [zh, zh, ch, -sh], [zh, zh, -sh, ch]]
-        )
+        Schoi = np.block([[ch, sh, zh, zh], [sh, ch, zh, zh], [zh, zh, ch, -sh], [zh, zh, -sh, ch]])
         # And then its Choi expanded symplectic
         S_exp = expand(S, list(range(l)), 2 * l) @ Schoi
         # And this is the corresponding covariance matrix
@@ -448,19 +420,14 @@ def probabilities(mu, cov, cutoff, parallel=False, hbar=2.0, rtol=1e-05, atol=1e
     if is_pure_cov(
         cov, hbar=hbar, rtol=rtol, atol=atol
     ):  # Check if the covariance matrix cov is pure
-        return (
-            np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar, check_purity=False))
-            ** 2
-        )
+        return np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar, check_purity=False)) ** 2
     num_modes = len(mu) // 2
 
     if parallel:
         compute_list = []
         # create a list of parallelizable computations
         for i in product(range(cutoff), repeat=num_modes):
-            compute_list.append(
-                dask.delayed(density_matrix_element)(mu, cov, i, i, hbar=hbar)
-            )
+            compute_list.append(dask.delayed(density_matrix_element)(mu, cov, i, i, hbar=hbar))
 
         probs = np.maximum(
             0.0, np.real_if_close(dask.compute(*compute_list, scheduler="processes"))
@@ -490,9 +457,7 @@ def loss_mat(eta, cutoff):  # pragma: no cover
     # If full transmission return the identity
 
     if eta < 0.0 or eta > 1.0:
-        raise ValueError(
-            "The transmission parameter eta should be a number between 0 and 1."
-        )
+        raise ValueError("The transmission parameter eta should be a number between 0 and 1.")
 
     if eta == 1.0:
         return np.identity(cutoff)
@@ -629,9 +594,7 @@ def _prefactor(mu, cov, hbar=2):
     return np.exp(-0.5 * beta @ Qinv @ beta.conj()) / np.sqrt(np.linalg.det(Q))
 
 
-def tvd_cutoff_bounds(
-    mu, cov, cutoff, hbar=2, check_is_valid_cov=True, rtol=1e-05, atol=1e-08
-):
+def tvd_cutoff_bounds(mu, cov, cutoff, hbar=2, check_is_valid_cov=True, rtol=1e-05, atol=1e-08):
     r"""Gives bounds of the total variation distance between the exact Gaussian Boson Sampling
     distribution extending to infinity in Fock space and the ones truncated by any value between 0
     and the user provided cutoff.
@@ -653,16 +616,12 @@ def tvd_cutoff_bounds(
     """
     if check_is_valid_cov:
         if not is_valid_cov(cov, hbar=hbar, rtol=rtol, atol=atol):
-            raise ValueError(
-                "The input covariance matrix violates the uncertainty relation."
-            )
+            raise ValueError("The input covariance matrix violates the uncertainty relation.")
     nmodes = cov.shape[0] // 2
     bounds = np.zeros([cutoff])
     for i in range(nmodes):
         mu_red, cov_red = reduced_state(mu, cov, [i])
-        ps = np.real_if_close(
-            np.diag(density_matrix(mu_red, cov_red, cutoff=cutoff, hbar=hbar))
-        )
+        ps = np.real_if_close(np.diag(density_matrix(mu_red, cov_red, cutoff=cutoff, hbar=hbar)))
         bounds += 1 - np.cumsum(ps)
     return bounds
 
@@ -705,16 +664,12 @@ def n_body_marginals(mean, cov, cutoff, n, hbar=2):
     """
     M = len(mean)
     if (M, M) != cov.shape:
-        raise ValueError(
-            "The covariance matrix and vector of means have incompatible dimensions"
-        )
+        raise ValueError("The covariance matrix and vector of means have incompatible dimensions")
     if M % 2 != 0:
         raise ValueError("The vector of means is not of even dimensions")
     M = M // 2
     if M < n:
-        raise ValueError(
-            "The order of the correlations is higher than the number of modes"
-        )
+        raise ValueError("The order of the correlations is higher than the number of modes")
 
     marginal = [np.zeros(([M] * i) + ([cutoff] * i)) for i in range(1, n + 1)]
 
@@ -722,16 +677,10 @@ def n_body_marginals(mean, cov, cutoff, n, hbar=2):
         modes = list(set(ind))
         acc = len(modes) - 1
         if list(ind) == sorted(ind):
-            sub_mean, sub_cov = reduced_state(
-                mean, cov, modes
-            )  # this happens in phase space
-            marginal[acc][tuple(modes)] = probabilities(
-                sub_mean, sub_cov, cutoff, hbar=hbar
-            )
+            sub_mean, sub_cov = reduced_state(mean, cov, modes)  # this happens in phase space
+            marginal[acc][tuple(modes)] = probabilities(sub_mean, sub_cov, cutoff, hbar=hbar)
         else:
             modes_usrt = list(OrderedDict.fromkeys(ind))
             perm = np.argsort(modes_usrt)
-            marginal[acc][tuple(modes_usrt)] = marginal[acc][tuple(modes)].transpose(
-                perm
-            )
+            marginal[acc][tuple(modes_usrt)] = marginal[acc][tuple(modes)].transpose(perm)
     return marginal

--- a/thewalrus/quantum/fock_tensors.py
+++ b/thewalrus/quantum/fock_tensors.py
@@ -267,24 +267,24 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
         np.array[complex]: the density matrix of the Gaussian state
     """
     N = len(mu) // 2
-    if type(cutoff) is int:
+    if isinstance(cutoff, int):
         cutoff = [cutoff] * N
     pref = _prefactor(mu, cov, hbar=hbar)
 
     if post_select is None:
         A = Amat(cov, hbar=hbar).conj()
         sf_order = tuple(chain.from_iterable([[i, i + N] for i in range(N)]))
-
+        cutoff_modified = [elem for _ in range(2)  for elem in cutoff]
         if np.allclose(mu, np.zeros_like(mu)):
-            tensor = pref * hermite_multidimensional(-A, [idx for _ in range(2)  for idx in cutoff], renorm=True, modified=True)
+            tensor = pref * hermite_multidimensional(-A, cutoff_modified, renorm=True, modified=True)
             return tensor.transpose(sf_order)
         beta = complex_to_real_displacements(mu, hbar=hbar)
         y = beta - A @ beta.conj()
-        tensor = pref * hermite_multidimensional(-A, [idx for _ in range(2)  for idx in cutoff], y=y, renorm=True, modified=True)
+        tensor = pref * hermite_multidimensional(-A, cutoff_modified, y=y, renorm=True, modified=True)
         return tensor.transpose(sf_order)
 
     M = N - len(post_select)
-    cutoff = [cutoff[i] for i in range(N) if not (i in post_select)]
+    cutoff = [cutoff[i] for i in range(N) if not i in post_select]
     rho = np.zeros([elem for _ in range(2) for elem in cutoff], dtype=np.complex128)
 
     for idx in product(*[range(n) for n in cutoff], repeat=2):

--- a/thewalrus/quantum/fock_tensors.py
+++ b/thewalrus/quantum/fock_tensors.py
@@ -274,7 +274,7 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
     if post_select is None:
         A = Amat(cov, hbar=hbar).conj()
         sf_order = tuple(chain.from_iterable([[i, i + N] for i in range(N)]))
-        cutoff_modified = [elem for _ in range(2)  for elem in cutoff]
+        cutoff_modified = cutoff * 2
         if np.allclose(mu, np.zeros_like(mu)):
             tensor = pref * hermite_multidimensional(-A, cutoff_modified, renorm=True, modified=True)
             return tensor.transpose(sf_order)

--- a/thewalrus/quantum/fock_tensors.py
+++ b/thewalrus/quantum/fock_tensors.py
@@ -285,7 +285,7 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
 
     M = N - len(post_select)
     cutoff = [cutoff[i] for i in range(N) if not i in post_select]
-    rho = np.zeros([elem for _ in range(2) for elem in cutoff], dtype=np.complex128)
+    rho = np.zeros(cutoff * 2, dtype=np.complex128)
 
     for idx in product(*[range(n) for n in cutoff], repeat=2):
         el = []

--- a/thewalrus/quantum/fock_tensors.py
+++ b/thewalrus/quantum/fock_tensors.py
@@ -30,7 +30,11 @@ from numba import jit
 from ..symplectic import expand, is_symplectic, reduced_state
 
 from .._hafnian import hafnian, hafnian_repeated, reduction
-from .._hermite_multidimensional import hermite_multidimensional, hafnian_batched, interferometer
+from .._hermite_multidimensional import (
+    hermite_multidimensional,
+    hafnian_batched,
+    interferometer,
+)
 
 from .conversions import (
     Amat,
@@ -42,7 +46,9 @@ from .conversions import (
 from .gaussian_checks import is_classical_cov, is_pure_cov, is_valid_cov
 
 
-def pure_state_amplitude(mu, cov, i, include_prefactor=True, tol=1e-10, hbar=2, check_purity=True):
+def pure_state_amplitude(
+    mu, cov, i, include_prefactor=True, tol=1e-10, hbar=2, check_purity=True
+):
     r"""Returns the :math:`\langle i | \psi\rangle` element of the state ket
     of a Gaussian state defined by covariance matrix cov.
 
@@ -64,7 +70,9 @@ def pure_state_amplitude(mu, cov, i, include_prefactor=True, tol=1e-10, hbar=2, 
     """
     if check_purity:
         if not is_pure_cov(cov, hbar=hbar, rtol=1e-05, atol=1e-08):
-            raise ValueError("The covariance matrix does not correspond to a pure state")
+            raise ValueError(
+                "The covariance matrix does not correspond to a pure state"
+            )
 
     rpt = i
     beta = complex_to_real_displacements(mu, hbar=hbar)
@@ -92,14 +100,23 @@ def pure_state_amplitude(mu, cov, i, include_prefactor=True, tol=1e-10, hbar=2, 
             haf = hafnian_repeated(B, rpt, mu=gamma, loop=True)
 
     if include_prefactor:
-        pref = np.exp(-0.5 * (np.linalg.norm(alpha) ** 2 - alpha.conj() @ B @ alpha.conj()))
+        pref = np.exp(
+            -0.5 * (np.linalg.norm(alpha) ** 2 - alpha.conj() @ B @ alpha.conj())
+        )
         haf *= pref
 
     return haf / np.sqrt(np.prod(fac(rpt)) * np.sqrt(np.linalg.det(Q)))
 
 
 def state_vector(
-    mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2, check_purity=True, **kwargs
+    mu,
+    cov,
+    post_select=None,
+    normalize=False,
+    cutoff=5,
+    hbar=2,
+    check_purity=True,
+    **kwargs
 ):
     r"""Returns the state vector of a (PNR post-selected) Gaussian state.
 
@@ -138,7 +155,9 @@ def state_vector(
     """
     if check_purity:
         if not is_pure_cov(cov, hbar=hbar, rtol=1e-05, atol=1e-08):
-            raise ValueError("The covariance matrix does not correspond to a pure state")
+            raise ValueError(
+                "The covariance matrix does not correspond to a pure state"
+            )
 
     beta = complex_to_real_displacements(mu, hbar=hbar)
     A = Amat(cov, hbar=hbar)
@@ -164,7 +183,11 @@ def state_vector(
             gamma = rescaling * gamma
             denom = np.sqrt(np.sqrt(np.linalg.det(Q / np.cosh(choi_r)).real))
 
-        psi = pref * hafnian_batched(B.conj(), cutoff, mu=gamma.conj(), renorm=True) / denom
+        psi = (
+            pref
+            * hafnian_batched(B.conj(), cutoff, mu=gamma.conj(), renorm=True)
+            / denom
+        )
     else:
         M = N - len(post_select)
         psi = np.zeros([cutoff] * (M), dtype=np.complex128)
@@ -174,7 +197,10 @@ def state_vector(
 
             counter = count(0)
             modes = (np.arange(N)).tolist()
-            el = [post_select[i] if i in post_select else idx[next(counter)] for i in modes]
+            el = [
+                post_select[i] if i in post_select else idx[next(counter)]
+                for i in modes
+            ]
             psi[idx] = pure_state_amplitude(
                 mu, cov, el, check_purity=False, include_prefactor=False, hbar=hbar
             )
@@ -274,18 +300,22 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
     if post_select is None:
         A = Amat(cov, hbar=hbar).conj()
         sf_order = tuple(chain.from_iterable([[i, i + N] for i in range(N)]))
-        cutoff_modified = cutoff * 2
+        cutoff_modified = [elem for _ in range(2) for elem in cutoff]
         if np.allclose(mu, np.zeros_like(mu)):
-            tensor = pref * hermite_multidimensional(-A, cutoff_modified, renorm=True, modified=True)
+            tensor = pref * hermite_multidimensional(
+                -A, cutoff_modified, renorm=True, modified=True
+            )
             return tensor.transpose(sf_order)
         beta = complex_to_real_displacements(mu, hbar=hbar)
         y = beta - A @ beta.conj()
-        tensor = pref * hermite_multidimensional(-A, cutoff_modified, y=y, renorm=True, modified=True)
+        tensor = pref * hermite_multidimensional(
+            -A, cutoff_modified, y=y, renorm=True, modified=True
+        )
         return tensor.transpose(sf_order)
 
     M = N - len(post_select)
     cutoff = [cutoff[i] for i in range(N) if not i in post_select]
-    rho = np.zeros(cutoff * 2, dtype=np.complex128)
+    rho = np.zeros([elem for _ in range(2) for elem in cutoff], dtype=np.complex128)
 
     for idx in product(*[range(n) for n in cutoff], repeat=2):
         el = []
@@ -301,7 +331,9 @@ def density_matrix(mu, cov, post_select=None, normalize=False, cutoff=5, hbar=2)
         sf_idx = np.array(idx).reshape(2, -1)
         sf_el = tuple(sf_idx[::-1].T.flatten())
 
-        rho[sf_el] = density_matrix_element(mu, cov, el0, el1, include_prefactor=False, hbar=hbar)
+        rho[sf_el] = density_matrix_element(
+            mu, cov, el0, el1, include_prefactor=False, hbar=hbar
+        )
 
     rho *= pref
 
@@ -352,7 +384,9 @@ def fock_tensor(
     m, _ = S.shape
     l = m // 2
     if l != len(alpha):
-        raise ValueError("The matrix S and the vector alpha do not have compatible dimensions")
+        raise ValueError(
+            "The matrix S and the vector alpha do not have compatible dimensions"
+        )
     # Check if S corresponds to an interferometer, if so use optimized routines
     if np.allclose(S @ S.T, np.identity(m), rtol=rtol, atol=atol) and np.allclose(
         alpha, 0, rtol=rtol, atol=atol
@@ -367,7 +401,9 @@ def fock_tensor(
         ch = np.cosh(choi_r) * np.identity(l)
         sh = np.sinh(choi_r) * np.identity(l)
         zh = np.zeros([l, l])
-        Schoi = np.block([[ch, sh, zh, zh], [sh, ch, zh, zh], [zh, zh, ch, -sh], [zh, zh, -sh, ch]])
+        Schoi = np.block(
+            [[ch, sh, zh, zh], [sh, ch, zh, zh], [zh, zh, ch, -sh], [zh, zh, -sh, ch]]
+        )
         # And then its Choi expanded symplectic
         S_exp = expand(S, list(range(l)), 2 * l) @ Schoi
         # And this is the corresponding covariance matrix
@@ -412,14 +448,19 @@ def probabilities(mu, cov, cutoff, parallel=False, hbar=2.0, rtol=1e-05, atol=1e
     if is_pure_cov(
         cov, hbar=hbar, rtol=rtol, atol=atol
     ):  # Check if the covariance matrix cov is pure
-        return np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar, check_purity=False)) ** 2
+        return (
+            np.abs(state_vector(mu, cov, cutoff=cutoff, hbar=hbar, check_purity=False))
+            ** 2
+        )
     num_modes = len(mu) // 2
 
     if parallel:
         compute_list = []
         # create a list of parallelizable computations
         for i in product(range(cutoff), repeat=num_modes):
-            compute_list.append(dask.delayed(density_matrix_element)(mu, cov, i, i, hbar=hbar))
+            compute_list.append(
+                dask.delayed(density_matrix_element)(mu, cov, i, i, hbar=hbar)
+            )
 
         probs = np.maximum(
             0.0, np.real_if_close(dask.compute(*compute_list, scheduler="processes"))
@@ -449,7 +490,9 @@ def loss_mat(eta, cutoff):  # pragma: no cover
     # If full transmission return the identity
 
     if eta < 0.0 or eta > 1.0:
-        raise ValueError("The transmission parameter eta should be a number between 0 and 1.")
+        raise ValueError(
+            "The transmission parameter eta should be a number between 0 and 1."
+        )
 
     if eta == 1.0:
         return np.identity(cutoff)
@@ -586,7 +629,9 @@ def _prefactor(mu, cov, hbar=2):
     return np.exp(-0.5 * beta @ Qinv @ beta.conj()) / np.sqrt(np.linalg.det(Q))
 
 
-def tvd_cutoff_bounds(mu, cov, cutoff, hbar=2, check_is_valid_cov=True, rtol=1e-05, atol=1e-08):
+def tvd_cutoff_bounds(
+    mu, cov, cutoff, hbar=2, check_is_valid_cov=True, rtol=1e-05, atol=1e-08
+):
     r"""Gives bounds of the total variation distance between the exact Gaussian Boson Sampling
     distribution extending to infinity in Fock space and the ones truncated by any value between 0
     and the user provided cutoff.
@@ -608,12 +653,16 @@ def tvd_cutoff_bounds(mu, cov, cutoff, hbar=2, check_is_valid_cov=True, rtol=1e-
     """
     if check_is_valid_cov:
         if not is_valid_cov(cov, hbar=hbar, rtol=rtol, atol=atol):
-            raise ValueError("The input covariance matrix violates the uncertainty relation.")
+            raise ValueError(
+                "The input covariance matrix violates the uncertainty relation."
+            )
     nmodes = cov.shape[0] // 2
     bounds = np.zeros([cutoff])
     for i in range(nmodes):
         mu_red, cov_red = reduced_state(mu, cov, [i])
-        ps = np.real_if_close(np.diag(density_matrix(mu_red, cov_red, cutoff=cutoff, hbar=hbar)))
+        ps = np.real_if_close(
+            np.diag(density_matrix(mu_red, cov_red, cutoff=cutoff, hbar=hbar))
+        )
         bounds += 1 - np.cumsum(ps)
     return bounds
 
@@ -656,12 +705,16 @@ def n_body_marginals(mean, cov, cutoff, n, hbar=2):
     """
     M = len(mean)
     if (M, M) != cov.shape:
-        raise ValueError("The covariance matrix and vector of means have incompatible dimensions")
+        raise ValueError(
+            "The covariance matrix and vector of means have incompatible dimensions"
+        )
     if M % 2 != 0:
         raise ValueError("The vector of means is not of even dimensions")
     M = M // 2
     if M < n:
-        raise ValueError("The order of the correlations is higher than the number of modes")
+        raise ValueError(
+            "The order of the correlations is higher than the number of modes"
+        )
 
     marginal = [np.zeros(([M] * i) + ([cutoff] * i)) for i in range(1, n + 1)]
 
@@ -669,10 +722,16 @@ def n_body_marginals(mean, cov, cutoff, n, hbar=2):
         modes = list(set(ind))
         acc = len(modes) - 1
         if list(ind) == sorted(ind):
-            sub_mean, sub_cov = reduced_state(mean, cov, modes)  # this happens in phase space
-            marginal[acc][tuple(modes)] = probabilities(sub_mean, sub_cov, cutoff, hbar=hbar)
+            sub_mean, sub_cov = reduced_state(
+                mean, cov, modes
+            )  # this happens in phase space
+            marginal[acc][tuple(modes)] = probabilities(
+                sub_mean, sub_cov, cutoff, hbar=hbar
+            )
         else:
             modes_usrt = list(OrderedDict.fromkeys(ind))
             perm = np.argsort(modes_usrt)
-            marginal[acc][tuple(modes_usrt)] = marginal[acc][tuple(modes)].transpose(perm)
+            marginal[acc][tuple(modes_usrt)] = marginal[acc][tuple(modes)].transpose(
+                perm
+            )
     return marginal

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -93,7 +93,10 @@ def test_reduced_gaussian(n):
     assert np.all(
         res[1]
         == np.array(
-            [[(N + 1) * n, (N + 1) * n + m], [(N + 1) * n + N * m, (N + 1) * n + N * m + m]]
+            [
+                [(N + 1) * n, (N + 1) * n + m],
+                [(N + 1) * n + N * m, (N + 1) * n + N * m + m],
+            ]
         )
     )
 
@@ -122,7 +125,9 @@ def test_reduced_gaussian_exceptions():
     mu = np.array([0, 0, 0, 0])
     cov = np.identity(4)
 
-    with pytest.raises(ValueError, match="Provided mode is larger than the number of subsystems."):
+    with pytest.raises(
+        ValueError, match="Provided mode is larger than the number of subsystems."
+    ):
         reduced_gaussian(mu, cov, [0, 5])
 
 
@@ -258,18 +263,24 @@ def test_density_matrix_element_vacuum():
 
     el = [[0], [0]]
     ex = 1
-    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
+    res = density_matrix_element(
+        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
+    )
     assert np.allclose(ex, res)
 
     el = [[1], [1]]
     #    res = density_matrix_element(beta, A, Q, el[0], el[1])
-    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
+    res = density_matrix_element(
+        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
+    )
 
     assert np.allclose(0, res)
 
     el = [[1], [0]]
     #    res = density_matrix_element(beta, A, Q, el[0], el[1])
-    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
+    res = density_matrix_element(
+        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
+    )
 
     assert np.allclose(0, res)
 
@@ -294,7 +305,9 @@ V = np.array(
 )
 
 
-mu = np.array([0.04948628, -0.55738964, 0.71298259, 0.17728629, -0.14381673, 0.33340778])
+mu = np.array(
+    [0.04948628, -0.55738964, 0.71298259, 0.17728629, -0.14381673, 0.33340778]
+)
 
 
 @pytest.mark.parametrize("t", [t0, t1, t2, t3, t4])
@@ -305,7 +318,9 @@ def test_density_matrix_element_disp(t):
 
     el = t[0]
     ex = t[1]
-    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
+    res = density_matrix_element(
+        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
+    )
     assert np.allclose(ex, res)
 
 
@@ -325,7 +340,9 @@ def test_density_matrix_element_no_disp(t):
 
     el = t[0]
     ex = t[1]
-    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
+    res = density_matrix_element(
+        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
+    )
     assert np.allclose(ex, res)
 
 
@@ -361,6 +378,8 @@ def test_density_matrix_squeezed():
         ]
     )
     assert np.allclose(res, expected)
+
+
 def test_density_matrix_vacuum_custom_cutoff():
     """Test custom cutoff"""
     mu = np.zeros([4])
@@ -369,6 +388,7 @@ def test_density_matrix_vacuum_custom_cutoff():
     res = density_matrix(mu, V, cutoff=[5, 3])
 
     assert res.shape == (5, 5, 3, 3)
+
 
 def test_coherent_squeezed():
     """Test density matrix for a squeezed displaced state"""
@@ -598,7 +618,11 @@ def test_pure_state_amplitude_two_mode_squeezed(i, j):
     if i != j:
         exact = 0.0
     else:
-        exact = np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar)
+        exact = (
+            np.exp(1j * i * phase)
+            * (nbar / (1.0 + nbar)) ** (i / 2)
+            / np.sqrt(1.0 + nbar)
+        )
     num = pure_state_amplitude(mu, cov, [i, j])
 
     assert np.allclose(exact, num)
@@ -711,7 +735,11 @@ def test_state_vector_two_mode_squeezed():
     mu = np.zeros([4], dtype=complex)
     exact = np.array(
         [
-            (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
+            (
+                np.exp(1j * i * phase)
+                * (nbar / (1.0 + nbar)) ** (i / 2)
+                / np.sqrt(1.0 + nbar)
+            )
             for i in range(cutoff)
         ]
     )
@@ -731,7 +759,11 @@ def test_state_vector_two_mode_squeezed_post():
     exact = np.diag(
         np.array(
             [
-                (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
+                (
+                    np.exp(1j * i * phase)
+                    * (nbar / (1.0 + nbar)) ** (i / 2)
+                    / np.sqrt(1.0 + nbar)
+                )
                 for i in range(cutoff)
             ]
         )
@@ -771,7 +803,11 @@ def test_state_vector_two_mode_squeezed_post_normalize():
     exact = np.diag(
         np.array(
             [
-                (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
+                (
+                    np.exp(1j * i * phase)
+                    * (nbar / (1.0 + nbar)) ** (i / 2)
+                    / np.sqrt(1.0 + nbar)
+                )
                 for i in range(cutoff)
             ]
         )
@@ -902,11 +938,35 @@ def test_single_mode_squeezing(choi_r, tol):
     # np.array(squeeze(40,r).data.todense())[0:5,0:5]
     expected = np.array(
         [
-            [0.80501818 + 0.0j, 0.0 + 0.0j, 0.43352515 + 0.0j, 0.0 + 0.0j, 0.2859358 + 0.0j],
+            [
+                0.80501818 + 0.0j,
+                0.0 + 0.0j,
+                0.43352515 + 0.0j,
+                0.0 + 0.0j,
+                0.2859358 + 0.0j,
+            ],
             [0.0 + 0.0j, 0.52169547 + 0.0j, 0.0 + 0.0j, 0.48661591 + 0.0j, 0.0 + 0.0j],
-            [-0.43352515 + 0.0j, 0.0 + 0.0j, 0.10462138 + 0.0j, 0.0 + 0.0j, 0.29199268 + 0.0j],
-            [0.0 + 0.0j, -0.48661591 + 0.0j, 0.0 + 0.0j, -0.23479643 + 0.0j, 0.0 + 0.0j],
-            [0.2859358 + 0.0j, 0.0 + 0.0j, -0.29199268 + 0.0j, 0.0 + 0.0j, -0.34474749 + 0.0j],
+            [
+                -0.43352515 + 0.0j,
+                0.0 + 0.0j,
+                0.10462138 + 0.0j,
+                0.0 + 0.0j,
+                0.29199268 + 0.0j,
+            ],
+            [
+                0.0 + 0.0j,
+                -0.48661591 + 0.0j,
+                0.0 + 0.0j,
+                -0.23479643 + 0.0j,
+                0.0 + 0.0j,
+            ],
+            [
+                0.2859358 + 0.0j,
+                0.0 + 0.0j,
+                -0.29199268 + 0.0j,
+                0.0 + 0.0j,
+                -0.34474749 + 0.0j,
+            ],
         ]
     )
     T = fock_tensor(S, alphas, cutoff, choi_r=choi_r)
@@ -1123,7 +1183,9 @@ def test_pnd_squeeze_displace(tol, r, phi, alpha, hbar):
     Phillips et al. (https://ris.utwente.nl/ws/files/122721825/PhysRevA.99.023836.pdf).
     """
     S = squeezing(r, phi)
-    mu = np.array([np.sqrt(2 * hbar) * np.real(alpha), np.sqrt(2 * hbar) * np.imag(alpha)])
+    mu = np.array(
+        [np.sqrt(2 * hbar) * np.real(alpha), np.sqrt(2 * hbar) * np.imag(alpha)]
+    )
 
     cov = hbar / 2 * (S @ S.T)
     pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
@@ -1138,7 +1200,9 @@ def test_pnd_squeeze_displace(tol, r, phi, alpha, hbar):
 
     mean_analytic = np.abs(alpha) ** 2 + np.sinh(r) ** 2
     assert np.isclose(float(pnd_cov.item()), pnd_cov_analytic, atol=tol, rtol=0)
-    assert np.isclose(photon_number_mean(mu, cov, 0, hbar=hbar), mean_analytic, atol=tol, rtol=0)
+    assert np.isclose(
+        photon_number_mean(mu, cov, 0, hbar=hbar), mean_analytic, atol=tol, rtol=0
+    )
 
 
 @pytest.mark.parametrize("hbar", [0.1, 1, 2])
@@ -1181,7 +1245,9 @@ def test_update_with_loss_two_mode_squeezed(etas, etai, parallel, hbar):
 
     cutoff = 6
     probs = probabilities(mean2, cov2l, cutoff, parallel=parallel, hbar=hbar)
-    probs_lossless = probabilities(mean2, cov2, 3 * cutoff, parallel=parallel, hbar=hbar)
+    probs_lossless = probabilities(
+        mean2, cov2, 3 * cutoff, parallel=parallel, hbar=hbar
+    )
     probs_updated = update_probabilities_with_loss(eta2, probs_lossless)
 
     assert np.allclose(probs, probs_updated[:cutoff, :cutoff], atol=1.0e-5)
@@ -1200,7 +1266,9 @@ def test_update_with_loss_coherent_states(etas, etai, parallel, hbar):
     means = 2 * np.random.rand(2 * n_modes)
     means_lossy = np.sqrt(np.array(eta_vals + eta_vals)) * means
     cutoff = 6
-    probs_lossless = probabilities(means, cov, 10 * cutoff, parallel=parallel, hbar=hbar)
+    probs_lossless = probabilities(
+        means, cov, 10 * cutoff, parallel=parallel, hbar=hbar
+    )
 
     probs = probabilities(means_lossy, cov, cutoff, parallel=parallel, hbar=hbar)
     probs_updated = update_probabilities_with_loss(eta_vals, probs_lossless)
@@ -1230,7 +1298,8 @@ def test_loss_value_error(eta):
     """Tests the correct error is raised"""
     n = 50
     with pytest.raises(
-        ValueError, match="The transmission parameter eta should be a number between 0 and 1."
+        ValueError,
+        match="The transmission parameter eta should be a number between 0 and 1.",
     ):
         loss_mat(eta, n)
 
@@ -1245,7 +1314,9 @@ def test_update_with_noise_coherent(num_modes, parallel):
     noise_dists = np.array([poisson.pmf(np.arange(cutoff), nbar) for nbar in nbar_vals])
     hbar = 2
     beta = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-    means = real_to_complex_displacements(np.concatenate((beta, beta.conj())), hbar=hbar)
+    means = real_to_complex_displacements(
+        np.concatenate((beta, beta.conj())), hbar=hbar
+    )
     cov = hbar * np.identity(2 * num_modes) / 2
     cutoff = 10
 
@@ -1267,7 +1338,9 @@ def test_update_with_noise_coherent_value_error():
     noise_dists = np.array([poisson.pmf(np.arange(cutoff), nbar) for nbar in nbar_vals])
     hbar = 2
     beta = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-    means = real_to_complex_displacements(np.concatenate((beta, beta.conj())), hbar=hbar)
+    means = real_to_complex_displacements(
+        np.concatenate((beta, beta.conj())), hbar=hbar
+    )
     cov = hbar * np.identity(2 * num_modes) / 2
     cutoff = 10
     probs = probabilities(means, cov, cutoff, hbar=2)
@@ -1311,8 +1384,12 @@ def test_fidelity_coherent_state(num_modes, hbar):
     """Test the fidelity of two multimode coherent states"""
     beta1 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
     beta2 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-    means1 = real_to_complex_displacements(np.concatenate([beta1, beta1.conj()]), hbar=hbar)
-    means2 = real_to_complex_displacements(np.concatenate([beta2, beta2.conj()]), hbar=hbar)
+    means1 = real_to_complex_displacements(
+        np.concatenate([beta1, beta1.conj()]), hbar=hbar
+    )
+    means2 = real_to_complex_displacements(
+        np.concatenate([beta2, beta2.conj()]), hbar=hbar
+    )
     cov1 = hbar * np.identity(2 * num_modes) / 2
     cov2 = hbar * np.identity(2 * num_modes) / 2
     fid = fidelity(means1, cov1, means2, cov2, hbar=hbar)
@@ -1330,7 +1407,9 @@ def test_fidelity_vac_to_displaced_squeezed(r, alpha, hbar):
     means2 = np.zeros([2])
     cov2 = np.identity(2) * hbar / 2
     expected = (
-        np.exp(-np.abs(alpha) ** 2) * np.abs(np.exp(np.tanh(r) * np.conj(alpha) ** 2)) / np.cosh(r)
+        np.exp(-np.abs(alpha) ** 2)
+        * np.abs(np.exp(np.tanh(r) * np.conj(alpha) ** 2))
+        / np.cosh(r)
     )
     assert np.allclose(expected, fidelity(means1, cov1, means2, cov2, hbar=hbar))
 
@@ -1351,7 +1430,9 @@ def test_fidelity_squeezed_vacuum(r1, r2, hbar):
 @pytest.mark.parametrize("hbar", [0.5, 1, 2, 1.6])
 def test_fidelity_thermal(n1, n2, hbar):
     """Test fidelity between two thermal states"""
-    expected = 1 / (1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1)))
+    expected = 1 / (
+        1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1))
+    )
     cov1 = hbar * (n1 + 0.5) * np.identity(2)
     cov2 = hbar * (n2 + 0.5) * np.identity(2)
     mu1 = np.zeros([2])
@@ -1478,7 +1559,18 @@ def test_expt_two_mode_squeezed(r, phi):
         [2, 2, 0, 0],
         [0, 0, 2, 2],
     ]
-    expected = [1, a, np.conj(a), adxa, adxa, a2, np.conj(a2), adxbdxab, ad2bd2, np.conj(ad2bd2)]
+    expected = [
+        1,
+        a,
+        np.conj(a),
+        adxa,
+        adxa,
+        a2,
+        np.conj(a2),
+        adxbdxab,
+        ad2bd2,
+        np.conj(ad2bd2),
+    ]
     for pattern, value in zip(patterns, expected):
         result = normal_ordered_expectation(means, cov, pattern, hbar=hbar)
         assert np.allclose(result, value)
@@ -1491,10 +1583,14 @@ def test_photon_number_expectation_displaced(alpha, hbar):
     beta = np.concatenate([alpha, np.conj(alpha)])
     means = real_to_complex_displacements(beta, hbar=hbar)
     cov = np.identity(len(beta)) * hbar / 2
-    val = photon_number_expectation(means, cov, modes=list(range(len(alpha))), hbar=hbar)
+    val = photon_number_expectation(
+        means, cov, modes=list(range(len(alpha))), hbar=hbar
+    )
     expected = np.prod(np.abs(alpha) ** 2)
     assert np.allclose(val, expected)
-    val = photon_number_squared_expectation(means, cov, modes=list(range(len(alpha))), hbar=hbar)
+    val = photon_number_squared_expectation(
+        means, cov, modes=list(range(len(alpha))), hbar=hbar
+    )
     expected = np.prod(np.abs(alpha) ** 4 + np.abs(alpha) ** 2)
     assert np.allclose(val, expected)
 
@@ -1587,7 +1683,11 @@ def test_tvd_cutoff_bounds():
     r = np.arcsinh(np.sqrt(nmean))
     V = two_mode_squeezing(2 * r, 0)
     mu = np.zeros([4])
-    probs = 1 / (1 + nmean) * np.array([((nmean) / (1 + nmean)) ** i for i in range(cutoff)])
+    probs = (
+        1
+        / (1 + nmean)
+        * np.array([((nmean) / (1 + nmean)) ** i for i in range(cutoff)])
+    )
     bound = tvd_cutoff_bounds(mu, V, cutoff)
     expected = np.array([2 * (1 - np.sum(probs[: i + 1])) for i in range(cutoff)])
     assert np.allclose(bound, expected)
@@ -1597,7 +1697,8 @@ def test_non_physical_cov_in_tvd():
     """Test the correct error is raised when an unphysical covariance matrix is passed to tvd_cutoff_bound"""
     A = np.array([[1, 2], [3, 4]])
     with pytest.raises(
-        ValueError, match="The input covariance matrix violates the uncertainty relation."
+        ValueError,
+        match="The input covariance matrix violates the uncertainty relation.",
     ):
         tvd_cutoff_bounds(np.zeros(2), A, 10)
 
@@ -1623,7 +1724,9 @@ def test_total_photon_number_distribution_values(s, k):
     cutoff = 300
     eta = 1.0
     expected_probs = _squeezed_state_distribution(s, cutoff, N=k)
-    probs = np.array([total_photon_number_distribution(i, k, s, eta) for i in range(cutoff)])
+    probs = np.array(
+        [total_photon_number_distribution(i, k, s, eta) for i in range(cutoff)]
+    )
     assert np.allclose(expected_probs, probs)
 
 
@@ -1664,7 +1767,9 @@ def test_characteristic_function_no_loss(s, k):
 
 
 @pytest.mark.parametrize("s", np.linspace(-1, 1, 9))
-@pytest.mark.parametrize("cov", [squeezing(2 * np.arcsinh(1), 0.0), 1.8 * np.identity(2)])
+@pytest.mark.parametrize(
+    "cov", [squeezing(2 * np.arcsinh(1), 0.0), 1.8 * np.identity(2)]
+)
 @pytest.mark.parametrize("mu", [np.zeros(2), np.array([0.9, 0.8])])
 @pytest.mark.parametrize("hbar", [0.5, 1.0, 1.7, 2.0])
 def test_s_ordered_expectation(s, cov, mu, hbar):
@@ -1727,12 +1832,18 @@ def test_photon_number_moment_two_mode_squeezed(r, theta, hbar):
     # Check expected squared photon numbers in each mode
     ind = {0: 2}
     nbar = np.sinh(r) ** 2
-    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
+    assert np.allclose(
+        2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar)
+    )
     ind = {1: 2}
-    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
+    assert np.allclose(
+        2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar)
+    )
     # Check expected value of the product of the photon numbers
     ind = {0: 1, 1: 1}
-    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
+    assert np.allclose(
+        2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar)
+    )
 
 
 @pytest.mark.parametrize("r", [0.5, 0.7, 2])
@@ -1793,7 +1904,8 @@ def test_n_body_marginals_mismatch_shape():
     cov = squeezing([2 * r1, 0, 2 * r2])
     mu = np.zeros([4])
     with pytest.raises(
-        ValueError, match="The covariance matrix and vector of means have incompatible dimensions"
+        ValueError,
+        match="The covariance matrix and vector of means have incompatible dimensions",
     ):
         n_body_marginals(mu, cov, 4, 3)
 
@@ -1804,7 +1916,9 @@ def test_n_body_marginals_not_even_shape():
     r2 = np.arcsinh(np.sqrt(2))
     cov = squeezing([2 * r1, 0, 2 * r2])
     mu = np.zeros([5])
-    with pytest.raises(ValueError, match="The vector of means is not of even dimensions"):
+    with pytest.raises(
+        ValueError, match="The vector of means is not of even dimensions"
+    ):
         n_body_marginals(mu, cov[:5, :5], 4, 3)
 
 
@@ -1815,7 +1929,8 @@ def test_n_body_marginals_too_high_correlation():
     cov = squeezing([2 * r1, 0, 2 * r2])
     mu = np.zeros([6])
     with pytest.raises(
-        ValueError, match="The order of the correlations is higher than the number of modes"
+        ValueError,
+        match="The order of the correlations is higher than the number of modes",
     ):
         n_body_marginals(mu, cov, 4, 4)
 

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -125,9 +125,7 @@ def test_reduced_gaussian_exceptions():
     mu = np.array([0, 0, 0, 0])
     cov = np.identity(4)
 
-    with pytest.raises(
-        ValueError, match="Provided mode is larger than the number of subsystems."
-    ):
+    with pytest.raises(ValueError, match="Provided mode is larger than the number of subsystems."):
         reduced_gaussian(mu, cov, [0, 5])
 
 
@@ -263,24 +261,18 @@ def test_density_matrix_element_vacuum():
 
     el = [[0], [0]]
     ex = 1
-    res = density_matrix_element(
-        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
-    )
+    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
     assert np.allclose(ex, res)
 
     el = [[1], [1]]
     #    res = density_matrix_element(beta, A, Q, el[0], el[1])
-    res = density_matrix_element(
-        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
-    )
+    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
 
     assert np.allclose(0, res)
 
     el = [[1], [0]]
     #    res = density_matrix_element(beta, A, Q, el[0], el[1])
-    res = density_matrix_element(
-        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
-    )
+    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
 
     assert np.allclose(0, res)
 
@@ -305,9 +297,7 @@ V = np.array(
 )
 
 
-mu = np.array(
-    [0.04948628, -0.55738964, 0.71298259, 0.17728629, -0.14381673, 0.33340778]
-)
+mu = np.array([0.04948628, -0.55738964, 0.71298259, 0.17728629, -0.14381673, 0.33340778])
 
 
 @pytest.mark.parametrize("t", [t0, t1, t2, t3, t4])
@@ -318,9 +308,7 @@ def test_density_matrix_element_disp(t):
 
     el = t[0]
     ex = t[1]
-    res = density_matrix_element(
-        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
-    )
+    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
     assert np.allclose(ex, res)
 
 
@@ -340,9 +328,7 @@ def test_density_matrix_element_no_disp(t):
 
     el = t[0]
     ex = t[1]
-    res = density_matrix_element(
-        real_to_complex_displacements(beta), Covmat(Q), el[0], el[1]
-    )
+    res = density_matrix_element(real_to_complex_displacements(beta), Covmat(Q), el[0], el[1])
     assert np.allclose(ex, res)
 
 
@@ -618,11 +604,7 @@ def test_pure_state_amplitude_two_mode_squeezed(i, j):
     if i != j:
         exact = 0.0
     else:
-        exact = (
-            np.exp(1j * i * phase)
-            * (nbar / (1.0 + nbar)) ** (i / 2)
-            / np.sqrt(1.0 + nbar)
-        )
+        exact = np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar)
     num = pure_state_amplitude(mu, cov, [i, j])
 
     assert np.allclose(exact, num)
@@ -735,11 +717,7 @@ def test_state_vector_two_mode_squeezed():
     mu = np.zeros([4], dtype=complex)
     exact = np.array(
         [
-            (
-                np.exp(1j * i * phase)
-                * (nbar / (1.0 + nbar)) ** (i / 2)
-                / np.sqrt(1.0 + nbar)
-            )
+            (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
             for i in range(cutoff)
         ]
     )
@@ -759,11 +737,7 @@ def test_state_vector_two_mode_squeezed_post():
     exact = np.diag(
         np.array(
             [
-                (
-                    np.exp(1j * i * phase)
-                    * (nbar / (1.0 + nbar)) ** (i / 2)
-                    / np.sqrt(1.0 + nbar)
-                )
+                (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
                 for i in range(cutoff)
             ]
         )
@@ -803,11 +777,7 @@ def test_state_vector_two_mode_squeezed_post_normalize():
     exact = np.diag(
         np.array(
             [
-                (
-                    np.exp(1j * i * phase)
-                    * (nbar / (1.0 + nbar)) ** (i / 2)
-                    / np.sqrt(1.0 + nbar)
-                )
+                (np.exp(1j * i * phase) * (nbar / (1.0 + nbar)) ** (i / 2) / np.sqrt(1.0 + nbar))
                 for i in range(cutoff)
             ]
         )
@@ -1183,9 +1153,7 @@ def test_pnd_squeeze_displace(tol, r, phi, alpha, hbar):
     Phillips et al. (https://ris.utwente.nl/ws/files/122721825/PhysRevA.99.023836.pdf).
     """
     S = squeezing(r, phi)
-    mu = np.array(
-        [np.sqrt(2 * hbar) * np.real(alpha), np.sqrt(2 * hbar) * np.imag(alpha)]
-    )
+    mu = np.array([np.sqrt(2 * hbar) * np.real(alpha), np.sqrt(2 * hbar) * np.imag(alpha)])
 
     cov = hbar / 2 * (S @ S.T)
     pnd_cov = photon_number_covmat(mu, cov, hbar=hbar)
@@ -1200,9 +1168,7 @@ def test_pnd_squeeze_displace(tol, r, phi, alpha, hbar):
 
     mean_analytic = np.abs(alpha) ** 2 + np.sinh(r) ** 2
     assert np.isclose(float(pnd_cov.item()), pnd_cov_analytic, atol=tol, rtol=0)
-    assert np.isclose(
-        photon_number_mean(mu, cov, 0, hbar=hbar), mean_analytic, atol=tol, rtol=0
-    )
+    assert np.isclose(photon_number_mean(mu, cov, 0, hbar=hbar), mean_analytic, atol=tol, rtol=0)
 
 
 @pytest.mark.parametrize("hbar", [0.1, 1, 2])
@@ -1245,9 +1211,7 @@ def test_update_with_loss_two_mode_squeezed(etas, etai, parallel, hbar):
 
     cutoff = 6
     probs = probabilities(mean2, cov2l, cutoff, parallel=parallel, hbar=hbar)
-    probs_lossless = probabilities(
-        mean2, cov2, 3 * cutoff, parallel=parallel, hbar=hbar
-    )
+    probs_lossless = probabilities(mean2, cov2, 3 * cutoff, parallel=parallel, hbar=hbar)
     probs_updated = update_probabilities_with_loss(eta2, probs_lossless)
 
     assert np.allclose(probs, probs_updated[:cutoff, :cutoff], atol=1.0e-5)
@@ -1266,9 +1230,7 @@ def test_update_with_loss_coherent_states(etas, etai, parallel, hbar):
     means = 2 * np.random.rand(2 * n_modes)
     means_lossy = np.sqrt(np.array(eta_vals + eta_vals)) * means
     cutoff = 6
-    probs_lossless = probabilities(
-        means, cov, 10 * cutoff, parallel=parallel, hbar=hbar
-    )
+    probs_lossless = probabilities(means, cov, 10 * cutoff, parallel=parallel, hbar=hbar)
 
     probs = probabilities(means_lossy, cov, cutoff, parallel=parallel, hbar=hbar)
     probs_updated = update_probabilities_with_loss(eta_vals, probs_lossless)
@@ -1314,9 +1276,7 @@ def test_update_with_noise_coherent(num_modes, parallel):
     noise_dists = np.array([poisson.pmf(np.arange(cutoff), nbar) for nbar in nbar_vals])
     hbar = 2
     beta = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-    means = real_to_complex_displacements(
-        np.concatenate((beta, beta.conj())), hbar=hbar
-    )
+    means = real_to_complex_displacements(np.concatenate((beta, beta.conj())), hbar=hbar)
     cov = hbar * np.identity(2 * num_modes) / 2
     cutoff = 10
 
@@ -1338,9 +1298,7 @@ def test_update_with_noise_coherent_value_error():
     noise_dists = np.array([poisson.pmf(np.arange(cutoff), nbar) for nbar in nbar_vals])
     hbar = 2
     beta = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-    means = real_to_complex_displacements(
-        np.concatenate((beta, beta.conj())), hbar=hbar
-    )
+    means = real_to_complex_displacements(np.concatenate((beta, beta.conj())), hbar=hbar)
     cov = hbar * np.identity(2 * num_modes) / 2
     cutoff = 10
     probs = probabilities(means, cov, cutoff, hbar=2)
@@ -1384,12 +1342,8 @@ def test_fidelity_coherent_state(num_modes, hbar):
     """Test the fidelity of two multimode coherent states"""
     beta1 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
     beta2 = np.random.rand(num_modes) + 1j * np.random.rand(num_modes)
-    means1 = real_to_complex_displacements(
-        np.concatenate([beta1, beta1.conj()]), hbar=hbar
-    )
-    means2 = real_to_complex_displacements(
-        np.concatenate([beta2, beta2.conj()]), hbar=hbar
-    )
+    means1 = real_to_complex_displacements(np.concatenate([beta1, beta1.conj()]), hbar=hbar)
+    means2 = real_to_complex_displacements(np.concatenate([beta2, beta2.conj()]), hbar=hbar)
     cov1 = hbar * np.identity(2 * num_modes) / 2
     cov2 = hbar * np.identity(2 * num_modes) / 2
     fid = fidelity(means1, cov1, means2, cov2, hbar=hbar)
@@ -1407,9 +1361,7 @@ def test_fidelity_vac_to_displaced_squeezed(r, alpha, hbar):
     means2 = np.zeros([2])
     cov2 = np.identity(2) * hbar / 2
     expected = (
-        np.exp(-np.abs(alpha) ** 2)
-        * np.abs(np.exp(np.tanh(r) * np.conj(alpha) ** 2))
-        / np.cosh(r)
+        np.exp(-np.abs(alpha) ** 2) * np.abs(np.exp(np.tanh(r) * np.conj(alpha) ** 2)) / np.cosh(r)
     )
     assert np.allclose(expected, fidelity(means1, cov1, means2, cov2, hbar=hbar))
 
@@ -1430,9 +1382,7 @@ def test_fidelity_squeezed_vacuum(r1, r2, hbar):
 @pytest.mark.parametrize("hbar", [0.5, 1, 2, 1.6])
 def test_fidelity_thermal(n1, n2, hbar):
     """Test fidelity between two thermal states"""
-    expected = 1 / (
-        1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1))
-    )
+    expected = 1 / (1 + n1 + n2 + 2 * n1 * n2 - 2 * np.sqrt(n1 * n2 * (n1 + 1) * (n2 + 1)))
     cov1 = hbar * (n1 + 0.5) * np.identity(2)
     cov2 = hbar * (n2 + 0.5) * np.identity(2)
     mu1 = np.zeros([2])
@@ -1583,14 +1533,10 @@ def test_photon_number_expectation_displaced(alpha, hbar):
     beta = np.concatenate([alpha, np.conj(alpha)])
     means = real_to_complex_displacements(beta, hbar=hbar)
     cov = np.identity(len(beta)) * hbar / 2
-    val = photon_number_expectation(
-        means, cov, modes=list(range(len(alpha))), hbar=hbar
-    )
+    val = photon_number_expectation(means, cov, modes=list(range(len(alpha))), hbar=hbar)
     expected = np.prod(np.abs(alpha) ** 2)
     assert np.allclose(val, expected)
-    val = photon_number_squared_expectation(
-        means, cov, modes=list(range(len(alpha))), hbar=hbar
-    )
+    val = photon_number_squared_expectation(means, cov, modes=list(range(len(alpha))), hbar=hbar)
     expected = np.prod(np.abs(alpha) ** 4 + np.abs(alpha) ** 2)
     assert np.allclose(val, expected)
 
@@ -1683,11 +1629,7 @@ def test_tvd_cutoff_bounds():
     r = np.arcsinh(np.sqrt(nmean))
     V = two_mode_squeezing(2 * r, 0)
     mu = np.zeros([4])
-    probs = (
-        1
-        / (1 + nmean)
-        * np.array([((nmean) / (1 + nmean)) ** i for i in range(cutoff)])
-    )
+    probs = 1 / (1 + nmean) * np.array([((nmean) / (1 + nmean)) ** i for i in range(cutoff)])
     bound = tvd_cutoff_bounds(mu, V, cutoff)
     expected = np.array([2 * (1 - np.sum(probs[: i + 1])) for i in range(cutoff)])
     assert np.allclose(bound, expected)
@@ -1724,9 +1666,7 @@ def test_total_photon_number_distribution_values(s, k):
     cutoff = 300
     eta = 1.0
     expected_probs = _squeezed_state_distribution(s, cutoff, N=k)
-    probs = np.array(
-        [total_photon_number_distribution(i, k, s, eta) for i in range(cutoff)]
-    )
+    probs = np.array([total_photon_number_distribution(i, k, s, eta) for i in range(cutoff)])
     assert np.allclose(expected_probs, probs)
 
 
@@ -1767,9 +1707,7 @@ def test_characteristic_function_no_loss(s, k):
 
 
 @pytest.mark.parametrize("s", np.linspace(-1, 1, 9))
-@pytest.mark.parametrize(
-    "cov", [squeezing(2 * np.arcsinh(1), 0.0), 1.8 * np.identity(2)]
-)
+@pytest.mark.parametrize("cov", [squeezing(2 * np.arcsinh(1), 0.0), 1.8 * np.identity(2)])
 @pytest.mark.parametrize("mu", [np.zeros(2), np.array([0.9, 0.8])])
 @pytest.mark.parametrize("hbar", [0.5, 1.0, 1.7, 2.0])
 def test_s_ordered_expectation(s, cov, mu, hbar):
@@ -1832,18 +1770,12 @@ def test_photon_number_moment_two_mode_squeezed(r, theta, hbar):
     # Check expected squared photon numbers in each mode
     ind = {0: 2}
     nbar = np.sinh(r) ** 2
-    assert np.allclose(
-        2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar)
-    )
+    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
     ind = {1: 2}
-    assert np.allclose(
-        2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar)
-    )
+    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
     # Check expected value of the product of the photon numbers
     ind = {0: 1, 1: 1}
-    assert np.allclose(
-        2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar)
-    )
+    assert np.allclose(2 * nbar**2 + nbar, photon_number_moment(mu, cov, ind, hbar=hbar))
 
 
 @pytest.mark.parametrize("r", [0.5, 0.7, 2])
@@ -1916,9 +1848,7 @@ def test_n_body_marginals_not_even_shape():
     r2 = np.arcsinh(np.sqrt(2))
     cov = squeezing([2 * r1, 0, 2 * r2])
     mu = np.zeros([5])
-    with pytest.raises(
-        ValueError, match="The vector of means is not of even dimensions"
-    ):
+    with pytest.raises(ValueError, match="The vector of means is not of even dimensions"):
         n_body_marginals(mu, cov[:5, :5], 4, 3)
 
 

--- a/thewalrus/tests/test_quantum.py
+++ b/thewalrus/tests/test_quantum.py
@@ -361,7 +361,14 @@ def test_density_matrix_squeezed():
         ]
     )
     assert np.allclose(res, expected)
+def test_density_matrix_vacuum_custom_cutoff():
+    """Test custom cutoff"""
+    mu = np.zeros([4])
+    V = np.identity(4)
 
+    res = density_matrix(mu, V, cutoff=[5, 3])
+
+    assert res.shape == (5, 5, 3, 3)
 
 def test_coherent_squeezed():
     """Test density matrix for a squeezed displaced state"""


### PR DESCRIPTION
**Context:**
'cutoff' argument for the 'density_matrix(mu, cov, post_select, normalize, cutoff, hbar)' function from 'fock_tensors.py' is the same for all modes

**Description of the Change:**
Added support of the 'list' type of 'cutoff' argument for the 'density_matrix(mu, cov, post_select, normalize, cutoff, hbar)' function from 'fock_tensors.py'. It enables to perform larger simulations.
Example: 4 bosonic modes
Hilbert space dimensions 20 for each mode => ~380 GB of RAM for a density matrix.
Hilbert space dimensions 20 for 2 main and 3 for auxiliary modes => 200 MB of RAM for a density matrix.

**Benefits:**
Enables users to choose different Hilbert space dimensions for different modes of a density matrix. It can be helpful for simulations with a large number of modes.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None
