### PR TITLE
Optimize loop hafnian: share powertrace computation between f_loop calls

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improvements
 
-* Improved speed of `loop_hafnian_batch_gamma` by 2-6x by hoisting powertrace computation outside inner loops [(#408)](https://github.com/XanaduAI/thewalrus/pull/408).
+* Improved speed of `loop_hafnian_batch_gamma` by 2-6x by hoisting powertrace computation outside inner loops [(#409)](https://github.com/XanaduAI/thewalrus/pull/409).
 
 * Improved speed of `_hermite_multidimensional_renorm` by 4x [(#404)](https://github.com/XanaduAI/thewalrus/pull/404).
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements
 
+* Improved speed of `loop_hafnian_batch_gamma` by 2-6x by hoisting powertrace computation outside inner loops [(#408)](https://github.com/XanaduAI/thewalrus/pull/408).
+
 * Improved speed of `_hermite_multidimensional_renorm` by 4x [(#404)](https://github.com/XanaduAI/thewalrus/pull/404).
 
 ### Bug fixes
@@ -20,8 +22,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-T.H. Dodd, L.G. Helt, F. Miatto, A. Motamedi
-
+T.H. Dodd, L.G. Helt, S. Madsen, F. Miatto, A. Motamedi
 ---
 
 # Release 0.22.0

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -243,7 +243,7 @@ def f_loop(AX_S, XD_S, D_S, n, powtrace_arr):
     return comb[count, :]
 
 
-# pylint: disable = too-many-arguments
+# pylint: disable = too-many-arguments, too-many-positional-arguments
 @numba.jit(nopython=True, cache=True)
 def f_loop_odd(AX_S, XD_S, D_S, n, oddloop, oddVX_S, powtrace_arr):
     """
@@ -748,7 +748,7 @@ def hafnian(
     Returns:
         int or float or complex: the hafnian of matrix ``A``
     """
-    # pylint: disable=too-many-return-statements,too-many-branches
+    # pylint: disable=too-many-return-statements,too-many-branches, possibly-used-before-assignment
     input_validation(A, rtol=rtol, atol=atol)
 
     matshape = A.shape
@@ -862,7 +862,7 @@ def hafnian_sparse(A, D=None, loop=False):
 
     return lhaf(D)
 
-
+# pylint: disable=too-many-positional-arguments
 def hafnian_repeated(A, rpt, mu=None, loop=False, rtol=1e-05, atol=1e-08, glynn=True):
     r"""Returns the hafnian of matrix with repeated rows/columns.
 

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -209,30 +209,31 @@ def f(A, n):  # pragma: no cover
     return comb[count, :]
 
 
-@numba.jit(nopython=True, cache=True)
-def f_loop(AX, AX_S, XD_S, D_S, n):  # pragma: no cover
-    """Evaluate the polynomial coefficients of the function in the eigenvalue-trace formula.
+@numba.jit(nopython=True, cache=True) # type: ignore
+def f_loop(AX_S, XD_S, D_S, n, powtrace_arr):
+    """
+    Evaluate polynomial coefficients using pre-computed powertrace.
+
+    OPTIMIZATION 1: Instead of computing powertrace(AX) internally,
+    we accept it as a parameter to avoid redundant computation.
 
     Args:
-        AX (array): two-dimensional matrix
-        AX_S (array): ``AX_S`` with weights given by repetitions and excluded rows removed
-        XD_S (array): diagonal multiplied by ``X``
-        D_S (array): diagonal
-        n (int): number of polynomial coefficients to compute
+        AX_S: AX_S with weights given by repetitions and excluded rows removed
+        XD_S: diagonal multiplied by X
+        D_S: diagonal
+        n: number of polynomial coefficients to compute
+        powtrace_arr: pre-computed power traces of AX matrix
 
     Returns:
         array: polynomial coefficients
     """
-    # Compute combinations in O(n^2log n) time
-    # code translated from thewalrus matlab script
     count = 0
     comb = np.zeros((2, n // 2 + 1), dtype=np.complex128)
     comb[0, 0] = 1
-    powtrace = charpoly.powertrace(AX, n // 2 + 1)
     for i in range(1, n // 2 + 1):
-        factor = powtrace[i] / (2 * i) + (XD_S @ D_S) / 2
+        factor = powtrace_arr[i] / (2 * i) + (XD_S @ D_S) / 2
         XD_S = XD_S @ AX_S
-        powfactor = 1
+        powfactor = 1.0
         count = 1 - count
         comb[count, :] = comb[1 - count, :]
         for j in range(1, n // (2 * i) + 1):
@@ -244,37 +245,39 @@ def f_loop(AX, AX_S, XD_S, D_S, n):  # pragma: no cover
 
 # pylint: disable = too-many-arguments
 @numba.jit(nopython=True, cache=True)
-def f_loop_odd(AX, AX_S, XD_S, D_S, n, oddloop, oddVX_S):  # pragma: no cover
-    """Evaluate the polynomial coefficients of the function in the eigenvalue-trace formula
-    when there is a self-edge in the fixed perfect matching.
+def f_loop_odd(AX_S, XD_S, D_S, n, oddloop, oddVX_S, powtrace_arr):
+    """
+    Evaluate polynomial coefficients for odd case using pre-computed powertrace.
+
+    OPTIMIZATION 1: Instead of computing powertrace(AX) internally,
+    we accept it as a parameter to avoid redundant computation when
+    both f_loop and f_loop_odd need the same powertrace.
 
     Args:
-        AX (array): two-dimensional matrix
-        AX_S (array): ``AX_S`` with weights given by repetitions and excluded rows removed
-        XD_S (array): diagonal multiplied by ``X``
-        D_S (array): diagonal
-        n (int): number of polynomial coefficients to compute
-        oddloop (float): weight of self-edge
-        oddVX_S (array): vector corresponding to matrix at the index of the self-edge
+        AX_S: AX_S with weights given by repetitions and excluded rows removed
+        XD_S: diagonal multiplied by X
+        D_S: diagonal
+        n: number of polynomial coefficients to compute
+        oddloop: weight of self-edge
+        oddVX_S: vector corresponding to matrix at the index of the self-edge
+        powtrace_arr: pre-computed power traces of AX matrix
 
     Returns:
         array: polynomial coefficients
     """
-
     count = 0
     comb = np.zeros((2, n + 1), dtype=np.complex128)
     comb[0, 0] = 1
-    powtrace = charpoly.powertrace(AX, n // 2 + 1)
     for i in range(1, n + 1):
         if i == 1:
             factor = oddloop
         elif i % 2 == 0:
-            factor = powtrace[i // 2] / i + (XD_S @ D_S) / 2
+            factor = powtrace_arr[i // 2] / i + (XD_S @ D_S) / 2
         else:
             factor = oddVX_S @ D_S
             D_S = AX_S @ D_S
 
-        powfactor = 1
+        powfactor = 1.0
         count = 1 - count
         comb[count, :] = comb[1 - count, :]
         for j in range(1, n // i + 1):
@@ -555,17 +558,16 @@ def _calc_loop_hafnian(A, D, edge_reps, oddloop=None, oddV=None, glynn=True):  #
             kept_edges = 2 * kept_edges - edge_reps
 
         AX_S, XD_S, D_S, oddVX_S = get_submatrices(kept_edges, A, D, oddV)
-        AX = AX_S.copy()
 
         prefac = (-1.0) ** (N // 2 - edge_sum) * binom_prod
-
+        AX_S_copy = AX_S.copy()
+        powtrace_arr = charpoly.powertrace(AX_S_copy, N // 2 + 1)
         if oddloop is not None:
-            Hnew = prefac * f_loop_odd(AX, AX_S, XD_S, D_S, N, oddloop, oddVX_S)[N]
+            Hnew = prefac * f_loop_odd(AX_S, XD_S, D_S, N, oddloop, oddVX_S, powtrace_arr)[N]
         else:
             if glynn and kept_edges[0] == 0:
                 prefac *= 0.5
-            Hnew = prefac * f_loop(AX, AX_S, XD_S, D_S, N)[N // 2]
-
+            Hnew = prefac * f_loop(AX_S, XD_S, D_S, N, powtrace_arr)[N // 2]
         H += Hnew
 
     if glynn:

--- a/thewalrus/_hafnian.py
+++ b/thewalrus/_hafnian.py
@@ -214,9 +214,6 @@ def f_loop(AX_S, XD_S, D_S, n, powtrace_arr):
     """
     Evaluate polynomial coefficients using pre-computed powertrace.
 
-    OPTIMIZATION 1: Instead of computing powertrace(AX) internally,
-    we accept it as a parameter to avoid redundant computation.
-
     Args:
         AX_S: AX_S with weights given by repetitions and excluded rows removed
         XD_S: diagonal multiplied by X
@@ -248,10 +245,6 @@ def f_loop(AX_S, XD_S, D_S, n, powtrace_arr):
 def f_loop_odd(AX_S, XD_S, D_S, n, oddloop, oddVX_S, powtrace_arr):
     """
     Evaluate polynomial coefficients for odd case using pre-computed powertrace.
-
-    OPTIMIZATION 1: Instead of computing powertrace(AX) internally,
-    we accept it as a parameter to avoid redundant computation when
-    both f_loop and f_loop_odd need the same powertrace.
 
     Args:
         AX_S: AX_S with weights given by repetitions and excluded rows removed

--- a/thewalrus/loop_hafnian_batch.py
+++ b/thewalrus/loop_hafnian_batch.py
@@ -48,7 +48,7 @@ from thewalrus._hafnian import (
 )
 
 
-# pylint: disable = too-many-arguments, not-an-iterable
+# pylint: disable = too-many-arguments, not-an-iterable, too-many-positional-arguments
 @numba.jit(nopython=True, parallel=True, cache=True)
 def _calc_loop_hafnian_batch_even(
     A, D, fixed_edge_reps, batch_max, odd_cutoff, glynn=True
@@ -125,7 +125,7 @@ def _calc_loop_hafnian_batch_even(
     return H_batch
 
 
-# pylint: disable = too-many-arguments, not-an-iterable
+# pylint: disable = too-many-arguments, not-an-iterable, too-many-positional-arguments
 @numba.jit(nopython=True, parallel=True, cache=True)
 def _calc_loop_hafnian_batch_odd(
     A, D, fixed_edge_reps, batch_max, even_cutoff, glynn=True
@@ -249,7 +249,7 @@ def add_batch_edges_odd(fixed_edges, oddmode):
         return np.array([1, oddmode, 1, 1], dtype=int)
     n_edges = fixed_edges.shape[0]
     edges = np.zeros(n_edges + 4, dtype=int)
-    new_edge = max(max(fixed_edges), oddmode) + 1
+    new_edge = max(*fixed_edges, oddmode) + 1
     edges[0] = new_edge
     edges[1] = oddmode
     edges[2 : n_edges // 2 + 2] = fixed_edges[: n_edges // 2]

--- a/thewalrus/loop_hafnian_batch.py
+++ b/thewalrus/loop_hafnian_batch.py
@@ -36,6 +36,7 @@ Code details
 """
 import numpy as np
 import numba
+from thewalrus import charpoly
 from thewalrus._hafnian import (
     precompute_binoms,
     matched_reps,
@@ -99,8 +100,9 @@ def _calc_loop_hafnian_batch_even(
 
         AX_S_copy = AX_S.copy()
 
-        f_even = f_loop(AX_S_copy, AX_S, XD_S, D_S, N_max)
-        f_odd = f_loop_odd(AX_S_copy, AX_S, XD_S, D_S, N_max, oddloop, oddVX_S)
+        powtrace_arr = charpoly.powertrace(AX_S_copy, N_max // 2 + 1)
+        f_even = f_loop(AX_S, XD_S, D_S, N_max, powtrace_arr)
+        f_odd = f_loop_odd(AX_S, XD_S, D_S, N_max, oddloop, oddVX_S, powtrace_arr)
 
         for N_det in range(2 * kept_edges[0], 2 * batch_max + odd_cutoff + 1):
             N = N_fixed + N_det
@@ -177,16 +179,16 @@ def _calc_loop_hafnian_batch_odd(
         AX_S, XD_S, D_S, oddVX_S = get_submatrices(delta, A, D, oddV)
 
         AX_S_copy = AX_S.copy()
+        powtrace_arr = charpoly.powertrace(AX_S_copy, N_max // 2 + 2)
 
         if kept_edges[0] == 0 and kept_edges[1] == 0:
             oddVX_S0 = get_submatrix_batch_odd0(delta, oddV0)
             plus_minus = (-1) ** (N_fixed // 2 - edges_sum)
-            f = f_loop_odd(AX_S_copy, AX_S, XD_S, D_S, N_fixed, oddloop0, oddVX_S0)[N_fixed]
+            f = f_loop_odd(AX_S, XD_S, D_S, N_fixed, oddloop0, oddVX_S0, powtrace_arr)[N_fixed]
             H_batch[0] += binom_prod * plus_minus * f
 
-        f_even = f_loop(AX_S_copy, AX_S, XD_S, D_S, N_max)
-        f_odd = f_loop_odd(AX_S_copy, AX_S, XD_S, D_S, N_max, oddloop, oddVX_S)
-
+        f_even = f_loop(AX_S, XD_S, D_S, N_max, powtrace_arr)
+        f_odd = f_loop_odd(AX_S, XD_S, D_S, N_max, oddloop, oddVX_S, powtrace_arr)
         for N_det in range(2 * kept_edges[0] + 1, 2 * batch_max + even_cutoff + 2):
             N = N_fixed + N_det
             plus_minus = (-1) ** (N // 2 - edges_sum)

--- a/thewalrus/loop_hafnian_batch_gamma.py
+++ b/thewalrus/loop_hafnian_batch_gamma.py
@@ -35,6 +35,7 @@ Code details
 import numpy as np
 import numba
 from numba import prange
+from thewalrus import charpoly
 from thewalrus._hafnian import (
     precompute_binoms,
     matched_reps,
@@ -100,12 +101,13 @@ def _calc_loop_hafnian_batch_gamma_even(
         AX_S, XD_S, D_S, oddVX_S = get_submatrices(delta, A, D[0, :], oddV)
 
         AX_S_copy = AX_S.copy()
+        powtrace_arr = charpoly.powertrace(AX_S_copy, N_max // 2 + 2)
 
         for k in range(n_D):
             XD_S, D_S = get_Dsubmatrices(delta, D[k, :])
 
-            f_even = f_loop(AX_S_copy, AX_S, XD_S, D_S, N_max)
-            f_odd = f_loop_odd(AX_S_copy, AX_S, XD_S, D_S, N_max, oddloop[k], oddVX_S)
+            f_even = f_loop(AX_S, XD_S, D_S, N_max, powtrace_arr)
+            f_odd = f_loop_odd(AX_S, XD_S, D_S, N_max, oddloop[k], oddVX_S, powtrace_arr)
 
             for N_det in range(2 * kept_edges[0], 2 * batch_max + odd_cutoff + 1):
                 N = N_fixed + N_det
@@ -185,6 +187,7 @@ def _calc_loop_hafnian_batch_gamma_odd(
         AX_S, XD_S, D_S, oddVX_S = get_submatrices(delta, A, D[0, :], oddV)
 
         AX_S_copy = AX_S.copy()
+        powtrace_arr = charpoly.powertrace(AX_S_copy, N_max // 2 + 2)
 
         for k in range(n_D):
             XD_S, D_S = get_Dsubmatrices(delta, D[k, :])
@@ -192,12 +195,11 @@ def _calc_loop_hafnian_batch_gamma_odd(
             if kept_edges[0] == 0 and kept_edges[1] == 0:
                 oddVX_S0 = get_submatrix_batch_odd0(delta, oddV0)
                 plus_minus = (-1) ** (N_fixed // 2 - edges_sum)
-                f = f_loop_odd(AX_S_copy, AX_S, XD_S, D_S, N_fixed, oddloop0[k], oddVX_S0)[N_fixed]
+                f = f_loop_odd(AX_S, XD_S, D_S, N_fixed, oddloop0[k], oddVX_S0, powtrace_arr)[N_fixed]
                 Hnew[k, 0] += binom_prod * plus_minus * f
 
-            f_even = f_loop(AX_S_copy, AX_S, XD_S, D_S, N_max)
-            f_odd = f_loop_odd(AX_S_copy, AX_S, XD_S, D_S, N_max, oddloop[k], oddVX_S)
-
+            f_even = f_loop(AX_S, XD_S, D_S, N_max, powtrace_arr)
+            f_odd = f_loop_odd(AX_S, XD_S, D_S, N_max, oddloop[k], oddVX_S, powtrace_arr)
             for N_det in range(2 * kept_edges[0] + 1, 2 * batch_max + even_cutoff + 2):
                 N = N_fixed + N_det
                 plus_minus = (-1) ** (N // 2 - edges_sum)

--- a/thewalrus/loop_hafnian_batch_gamma.py
+++ b/thewalrus/loop_hafnian_batch_gamma.py
@@ -49,7 +49,7 @@ from thewalrus._hafnian import (
 from thewalrus.loop_hafnian_batch import add_batch_edges_odd, add_batch_edges_even
 
 
-# pylint: disable = too-many-arguments, not-an-iterable
+# pylint: disable = too-many-arguments, not-an-iterable, too-many-positional-arguments
 @numba.jit(nopython=True, cache=True, parallel=True)
 def _calc_loop_hafnian_batch_gamma_even(
     A, D, fixed_edge_reps, batch_max, odd_cutoff, glynn=True
@@ -129,7 +129,7 @@ def _calc_loop_hafnian_batch_gamma_even(
     return H_batch
 
 
-# pylint: disable = too-many-arguments, not-an-iterable
+# pylint: disable = too-many-arguments, not-an-iterable, too-many-positional-arguments
 @numba.jit(nopython=True, cache=True, parallel=True)
 def _calc_loop_hafnian_batch_gamma_odd(
     A, D, fixed_edge_reps, batch_max, even_cutoff, glynn=True


### PR DESCRIPTION
**Context:**
In `_calc_loop_hafnian_batch_gamma_even` and `_calc_loop_hafnian_batch_gamma_odd`, the functions `f_loop()` and `f_loop_odd()` are called inside a loop over displacement vectors (`k in range(n_D)`). Both functions internally compute `powertrace(AX)`, however, the matrix `AX` depends only on the edge configuration (`j`), and **not** on the displacement vector (`D[k]`). The original code redundantly computes the same powertrace `2 × n_D` times per `j` iteration.

**Description of the Change:**

1. Modified `f_loop` and `f_loop_odd` in `_hafnian.py` to accept `powtrace_arr` as a parameter instead of computing it internally.
2. Updated callers in `loop_hafnian_batch.py` and loop_hafnian_batch_gamma.py to compute powertrace once per `j` iteration and pass it to both functions.

**Benefits:**

- **2-6x speedup** on `loop_hafnian_batch_gamma` for typical batch sizes (10-50 displacement vectors)
- Speedup scales with batch size — minimal overhead for batch_size=1, significant gains for larger batches
- Benchmark results on Apple M3 Pro and M1 Pro available at: https://github.com/seba2390/thewalrus_opt_benchmark

**Possible Drawbacks:**

- Changes the internal API of `f_loop` and `f_loop_odd` (now require `powtrace_arr` parameter). These are internal functions not exposed in the public API.

**Related GitHub Issues:**

None